### PR TITLE
Remove double back fix

### DIFF
--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -788,7 +788,7 @@
       },
 
       _demoClicked: function() {
-        this._currentPath = document.location.href;
+        this._navigatedToDemo = true;
       },
 
       _showDemo: function() {
@@ -809,7 +809,7 @@
       },
 
       _closeDemo: function() {
-        this._currentPath = '';
+        this._navigatedToDemo = false;
         if (!this.$['demo-dialog'].opened)
           return;
         if (this.$['demo-dialog'].hasAttribute('unresolved'))
@@ -829,22 +829,13 @@
       },
 
       _demoCanceled: function() {
-        if (this._currentPath) {
+        if (this._navigatedToDemo) {
           history.back();
-          // The demo frame loading sometimes causes the browser to store extra
-          // history state. This attempts to restore again. Also note
-          // history.back() is not synchronous, so we need to wait to read path.
-          this.async(this._ensureNavigationMatches.bind(this, this._currentPath));
         } else {
           history.replaceState({}, document.title, this.route.prefix + '/' + this.owner + '/' + this.repo + this.versionRoute);
           this.fire('location-changed');
         }
         this._dialogDemoLoading = false;
-      },
-
-      _ensureNavigationMatches: function(path) {
-        if (document.location.href != path)
-          history.back();
       },
 
       _updateLoading: function(metaLoading, data) {


### PR DESCRIPTION
Turns out that reading window.location.href is super unreliable after history.back(). It's never clear if its the old or new page.

This "fixed" some cases, but broke others in worse ways so reverting this part of the change.