### PR TITLE
Limit infinite scroll to behind an extra click

### DIFF
--- a/client/src/catalog-community.html
+++ b/client/src/catalog-community.html
@@ -86,6 +86,7 @@
           <template is="dom-repeat" items="[[_resources.results]]">
             <catalog-community-item data="[[item]]"></catalog-community-item>
           </template>
+          <div id="load-more" hidden$="[[_hideLoadMoreButton]]" class="soft-button-bold" on-click="_loadMoreClick">Load more</div>
           <progress-bar indeterminate hidden$="[[!_resourcesLoading]]"></progress-bar>
         </div>
 
@@ -133,6 +134,16 @@
 
         // Article content
         _content: Object,
+
+        _hideLoadMoreButton: {
+          type: Boolean,
+          value: true,
+        },
+
+        _preventManyScrollLoads: {
+          type: Boolean,
+          value: true,
+        },
       },
 
       ready: function() {
@@ -144,13 +155,26 @@
         if (visible) {
           this.$.threshold.clearTriggers();
           this.$.threshold.checkScrollThesholds();
+          this._preventManyScrollLoads = true;
         }
       },
 
       _loadMore: function() {
         if (!this.visible || (this.path && !this._filterPath) || !this._resources || this._resources.results.length >= this._resources.count)
           return;
+
+        if (this._resources.results.length >= 10 && this._preventManyScrollLoads) {
+          this._hideLoadMoreButton = false;
+          return;
+        }
+
         this.$.ajax.params = {offset: this._resources.results.length};
+      },
+
+      _loadMoreClick: function() {
+        this._hideLoadMoreButton = true;
+        this._preventManyScrollLoads = false;
+        this._loadMore();
       },
 
       _onResourcesResponse: function() {

--- a/client/src/catalog-list.html
+++ b/client/src/catalog-list.html
@@ -41,6 +41,10 @@
         position: relative;
         overflow: visible;
       }
+
+      .soft-button-bold {
+        margin-top: 16px;
+      }
     </style>
 
 
@@ -90,6 +94,7 @@
       </template>
     </div>
     <progress-bar indeterminate hidden$="[[!_and(_elementsLoading, _elements)]]"></progress-bar>
+    <div class="soft-button-bold" hidden$="[[_hideLoadMore]]" on-click="_loadMoreClick">Load more</div>
     <iron-scroll-threshold on-lower-threshold="_loadMore" id="threshold" scroll-target="document" lower-threshold="800"></iron-scroll-threshold>
   </template>
 
@@ -128,6 +133,14 @@
         },
         _collections: Object,
         _elements: Object,
+        _hideLoadMore: {
+          value: true,
+          type: Boolean,
+        },
+        _preventManyScrollLoads: {
+          value: true,
+          type: Boolean,
+        },
       },
 
       observers: [
@@ -152,9 +165,19 @@
           // Only keep adding collections if there's no elements.
           this._loadMoreCollections();
         } else if (this._elements && this._elements.cursor) {
+          if (this._elements.results.length >= 20 && this._preventManyScrollLoads) {
+            this._hideLoadMore = false;
+            return;
+          }
           this._elementRequestParams.cursor = this._elements.cursor;
           this.$.elementsAjax.generateRequest();
         }
+      },
+
+      _loadMoreClick: function() {
+        this._hideLoadMore = true;
+        this._preventManyScrollLoads = false;
+        this._loadMore();
       },
 
       _loadMoreCollections: function() {
@@ -179,6 +202,7 @@
 
       _queryChanged: function(query, disabled) {
         var active = !disabled && query;
+        this._preventManyScrollLoads = true;
         this.$.threshold.toggleScrollListener(active);
         if (!active || this._currentQuery == query)
           return;

--- a/client/src/catalog-styles.html
+++ b/client/src/catalog-styles.html
@@ -247,13 +247,24 @@
       }
 
       .soft-button {
-        display: block;
         border: 1px solid #ededed;
         border-radius: 4px;
         width: 100%;
         display: flex;
         padding: 12px 0;
         color: inherit;
+        justify-content: center;
+      }
+
+      .soft-button-bold {
+        display: block;
+        width: 100%;
+        background: var(--theme-blue);
+        display: flex;
+        border-radius: 4px;
+        padding: 12px 0;
+        color: white;
+        font-weight: 600;
         justify-content: center;
       }
 


### PR DESCRIPTION
Fixes #808 

After a set limit of dynamic loads, a "Load more" button appears. This way the footer remains accessible on all pages. After the "Load more" button it pressed, the normal infinite scroll behavior returns till the page is navigated away.

![image](https://cloud.githubusercontent.com/assets/787668/22192672/09a3afb8-e18a-11e6-98d8-f24b04be8114.png)
