### PR TITLE
Generate new requests for loaded error pages

### DIFF
--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -791,7 +791,7 @@
         if (prefix == '/preview' && path == '')
           return;
 
-        if (path == this._currentPath)
+        if (this._currentPath == path && (this._metaLoading || this.data))
           return;
 
         this._currentPath = path;
@@ -803,7 +803,7 @@
         this._repoStarred = this._isStarred();
 
         // Generate requests
-        if (this._currentOwner != this.owner || this._currentRepo != this.repo || this._currentVersionRoute != this.versionRoute) {
+        if (!this.data || this._currentOwner != this.owner || this._currentRepo != this.repo || this._currentVersionRoute != this.versionRoute) {
           this._currentOwner = this.owner;
           this._currentRepo = this.repo;
           this._currentVersionRoute = this.versionRoute;


### PR DESCRIPTION
Fixes #827 

A bug exists resulting in forever-loading state:
 * Go to an element page with an error (eg. after publishing it)
 * Navigate internally (eg. to publish)
 * Navigate internally to the same element page (eg. republishing the same error'd element)

In non-error cases, the page will simply re-use the old result and display the page instantly. Here, a) the `updateLoading()` method assumed `data` is never null and b) it won't generate new API requests.

By generating new API requests in this error case, loading will be completed when the new API request completes.