### PR TITLE
Fix navigation issues by moving the sidebar to left, compacting view

### DIFF
--- a/client/src/activity-graph.html
+++ b/client/src/activity-graph.html
@@ -4,7 +4,7 @@
   <template>
     <style>
       #container {
-        width: 326px;
+        width: 100%;
         height: 110px;
         position: relative;
         overflow: hidden;
@@ -30,16 +30,8 @@
       }
 
       @media (max-width: 700px) {
-        #container {
-          width: 194px;
-        }
-
-        #startDate {
+        .date {
           display: none;
-        }
-
-        #today-9 {
-          display: inline-block;
         }
       }
     </style>
@@ -48,7 +40,7 @@
       <svg id="svg" height="86"></svg>
       <div id="today" class="date">[[_date(0)]]</div>
       <div id="today-9" class="date">[[_date(9)]]</div>
-      <div id="startDate" class="date">[[_date(45)]]</div>
+      <div id="startDate" class="date">[[_date(44)]]</div>
     </div>
   </template>
 
@@ -83,17 +75,17 @@
         this.$.svg.innerHTML = '';
         var columnWidth = 18;
         var spacing = 4;
-        var width = (columnWidth + spacing) * 15 - spacing;
+        var width = (columnWidth + spacing) * 11 - spacing;
         this.$.svg.setAttribute('width', width);
 
         var buckets = [];
         var maxCommits = 20;
 
-        // Use the 45 most recent weeks
-        activity = activity.slice(52 - 45);
+        // Use the 44 most recent weeks
+        activity = activity.slice(52 - 44);
         var i;
         for (i = 0; i < activity.length; i++) {
-          var bucket = Math.floor(i / 3);
+          var bucket = Math.floor(i / 4);
           buckets[bucket] = (buckets[bucket] || 0) + activity[i];
           maxCommits = Math.max(buckets[bucket], maxCommits);
         }

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -7,6 +7,7 @@
 <link rel="import" href="catalog-api-doc.html">
 <link rel="import" href="catalog-element-readme.html">
 <link rel="import" href="collection-card.html">
+<link rel="import" href="github-info.html">
 <link rel="import" href="page-loading-behavior.html">
 <link rel="import" href="lazy-block.html">
 
@@ -19,6 +20,15 @@
         align-items: flex-end;
         margin-bottom: 8px;
         margin-left: -36px;
+      }
+
+      .main-content {
+        margin-right: 0;
+        margin-left: 40px;
+      }
+
+      .sidebar {
+        order: 0;
       }
 
       h1.page-title {
@@ -94,11 +104,11 @@
       }
 
       #header-main > div {
-        padding: 12px 16px;
+        /*padding: 12px 16px;*/
       }
 
       #header-main > div:not(:first-child) {
-        border-top: 1px solid #ededed;
+        /*border-top: 1px solid #ededed;*/
       }
 
       /* Repo info */
@@ -481,104 +491,10 @@
 
     <div id="container">
 
-      <!-- Header -->
-      <div>
-        <div id="title">
-          <svg id="star" class="desktop-only" viewBox="0 0 100 100" class="octicon octicon-star" on-click="_authenticateStar" title="Star this repository" starred$="[[_repoStarred]]">
-            <use xlink:href="/sprite.octicons.svg#star"></use>
-          </svg>
-          <h1 class="page-title">[[repo]]</h1>
-          <template is="dom-if" if="[[!_contains(data.versions, data.version)]]">
-            <div id="version-sha">[[data.version]]</div>
-          </template>
-          <template is="dom-if" if="[[_contains(data.versions, data.version)]]">
-            <select id="version-select" on-change="_versionChanged" latest$="[[_equal(data.version, data.default_version)]]">
-              <template is="dom-repeat" items="[[_reverse(data.versions)]]">
-                <option selected$="[[_equal(item, data.version)]]" latest$="[[_equal(item, data.default_version)]]">[[item]]</option>
-              </template>
-            </select>
-          </template>
-          <a id="github-mobile-link" href="https://github.com/[[owner]]/[[repo]]" class="mobile-only">
-            <svg viewBox="0 0 100 100"><use xlink:href="/sprite.octicons.svg#mark-github"></use></svg>
-          </a>
-        </div>
-        <h2 class="page-subtitle">[[data.description]] <a title="Home page link" href="[[data.homepage]]" hidden$="[[_redundantLink(data.homepage)]]">[[data.homepage]]</a></h2>
-      </div>
-
-      <div id="header" class="body">
-        <div id="header-main" class="main-content box">
-          <!-- Repo info -->
-          <div id="info-header">
-            <div id="repo-author">
-              <img class="avatar" src="[[data.avatar_url]]&s=[[_dpr(40)]]" role="presentation">
-              <span>by <a href="/author/[[owner]]">[[owner]]</a></span>
-            </div>
-            <div id="info-stats">
-              <div title="[[data.stars]] users starred this repository">
-                <svg viewBox="0 0 100 100" class="octicon octicon-star">
-                 <use xlink:href="/sprite.octicons.svg#star"></use>
-                </svg>
-                [[data.stars]]
-              </div>
-              <div title="[[data.forks]] users forked this repository">
-                <svg viewBox="0 0 100 100" class="octicon octicon-repo-forked">
-                 <use xlink:href="/sprite.octicons.svg#repo-forked"></use>
-                </svg>
-                [[data.forks]]
-              </div>
-              <div title="[[data.subscribers]] users are watching this repository">
-                <svg viewBox="0 0 100 100" class="octicon octicon-eye">
-                 <use xlink:href="/sprite.octicons.svg#eye"></use>
-                </svg>
-                [[data.subscribers]]
-              </div>
-              <div title="[[data.open_issues]] open issues and pull requests in this repository">
-                <svg viewBox="0 0 100 100" class="octicon octicon-issue-opened">
-                 <use xlink:href="/sprite.octicons.svg#issue-opened"></use>
-                </svg>
-                [[data.open_issues]]
-              </div>
-            </div>
-          </div>
-
-          <div id="info-body" body-collapsed$="[[_infoBodyCollapsed]]">
-            <div id="info-contributors">
-              <h3>[[data.contributors.length]] contributor[[_s(data.contributors.length)]]</h3>
-              <contributors-list contributors="[[data.contributors]]"></contributors-list>
-            </div>
-            <div id="info-graph">
-              <h3>[[_lastUpdated(data.activity)]]</h3>
-              <activity-graph activity="[[data.activity]]"></activity-graph>
-            </div>
-          </div>
-
-          <div id="info-footer">
-            <div id="info-license">
-              <h3>License</h3>
-              <a href="https://spdx.org/licenses/[[data.spdx_identifier]]" target="_blank">[[data.spdx_identifier]]</a>
-            </div>
-            <div id="info-tags">
-              <h3>Tags</h3>
-              <template is="dom-repeat" items="[[data.bower.keywords]]">
-                <a href="#" tag="[[item]]" on-click="_searchTag">[[item]]</a>
-              </template>
-            </div>
-            <div id="expand-collapse" on-tap="_toggleExpand" body-collapsed$="[[_infoBodyCollapsed]]">
-              <template is="dom-if" if="[[_infoBodyCollapsed]]">
-                <svg viewBox="0 0 100 100" class="octicon octicon-plus">
-                  <use xlink:href="/sprite.octicons.svg#plus"></use>
-                </svg>
-              </template>
-              <template is="dom-if" if="[[!_infoBodyCollapsed]]">
-                <svg viewBox="0 0 100 100" class="octicon octicon-dash">
-                 <use xlink:href="/sprite.octicons.svg#dash"></use>
-                </svg>
-              </template>
-            </div>
-          </div>
-        </div>
-
-        <div id="header-sidebar" class="sidebar desktop-only">
+      <div class="body">
+        <!-- Repository contents sidebar -->
+        <div class="sidebar">
+          <github-info data="[[data]]" class="box"></github-info>
           <div class="box">
             <div id="info-download">
               <h3>Download</h3>
@@ -591,12 +507,7 @@
           </div>
 
           <a href="/publish/[[owner]]/[[repo]]" class="soft-button" hidden$="[[!_isPreview(route.prefix)]]">Publish</a>
-        </div>
-      </div>
 
-      <div class="body">
-        <!-- Repository contents sidebar -->
-        <div class="sidebar">
           <h1 hidden$="[[!_hasRepoContents]]">Repository contents</h1>
 
           <spinner-lite id="sidebar-spinner"></spinner-lite>
@@ -663,6 +574,29 @@
 
         <!-- Main content pane -->
         <div id="main-content" class="main-content">
+          <div id="title">
+            <svg id="star" class="desktop-only" viewBox="0 0 100 100" class="octicon octicon-star" on-click="_authenticateStar" title="Star this repository" starred$="[[_repoStarred]]">
+              <use xlink:href="/sprite.octicons.svg#star"></use>
+            </svg>
+            <h1 class="page-title">[[repo]]</h1>
+            <template is="dom-if" if="[[!_contains(data.versions, data.version)]]">
+              <div id="version-sha">[[data.version]]</div>
+            </template>
+            <template is="dom-if" if="[[_contains(data.versions, data.version)]]">
+              <select id="version-select" on-change="_versionChanged" latest$="[[_equal(data.version, data.default_version)]]">
+                <template is="dom-repeat" items="[[_reverse(data.versions)]]">
+                  <option selected$="[[_equal(item, data.version)]]" latest$="[[_equal(item, data.default_version)]]">[[item]]</option>
+                </template>
+              </select>
+            </template>
+            <a id="github-mobile-link" href="https://github.com/[[owner]]/[[repo]]" class="mobile-only">
+              <svg viewBox="0 0 100 100"><use xlink:href="/sprite.octicons.svg#mark-github"></use></svg>
+            </a>
+          </div>
+          <h2 class="page-subtitle">[[data.description]] <a title="Home page link" href="[[data.homepage]]" hidden$="[[_redundantLink(data.homepage)]]">[[data.homepage]]</a></h2>
+
+
+
           <h1 hidden="[[subElement]]">README.md</h1>
           <template is="dom-if" if="[[data]]">
             <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!docs]]" readme="[[data.readme]]" base-urls="[[baseUrls]]" hidden="[[subElement]]"></catalog-element-readme>

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -16,38 +16,48 @@
     <style include="catalog-styles"></style>
     <style>
       #title {
-        display: flex;
         align-items: flex-end;
         margin-bottom: 8px;
-        margin-left: -36px;
-      }
-
-      .main-content {
-        margin-right: 0;
-        margin-left: 40px;
       }
 
       .sidebar {
         order: 0;
+        margin: 0 40px 0 0;
       }
 
       h1.page-title {
         margin-bottom: 0;
       }
 
-      #star {
+      #star-button {
+        display: flex;
+        align-items: center;
+        padding: 12px 16px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      #star-button svg {
         width: 24px;
         height: 24px;
         stroke: hsl(0, 0%, 45%);
         fill: transparent;
         margin-right: 12px;
-        margin-bottom: 6px;
         cursor: pointer;
+        transition: fill 150ms, stroke 150ms;
       }
 
-      #star:hover, #star[starred] {
+      #star-button:hover svg, #star-button[starred] svg {
         fill: #f3b70b;
         stroke: #f3b70b;
+      }
+
+      #star-button > div:after {
+        content: 'Requires authentication';
+        display: block;
+        font-weight: normal;
+        color: var(--theme-blue-grey);
+        font-size: 14px;
       }
 
       #version-select, #version-sha {
@@ -84,128 +94,7 @@
         margin: 0;
       }
 
-      /* Header */
-      #header {
-        margin-bottom: 40px;
-        align-items: flex-start;
-      }
-
-      #header-main {
-        color: var(--theme-blue-grey);
-      }
-
-      h3 {
-        text-transform: uppercase;
-        font-size: 13px;
-        line-height: 16px;
-        font-weight: 600;
-        margin: 0;
-        margin-bottom: 8px;
-      }
-
-      #header-main > div {
-        /*padding: 12px 16px;*/
-      }
-
-      #header-main > div:not(:first-child) {
-        /*border-top: 1px solid #ededed;*/
-      }
-
       /* Repo info */
-
-      #info-header {
-        display: flex;
-      }
-
-      #info-header > div:first-child, #info-body > div:first-child {
-        flex: 0 0 270px;
-        margin-right: 32px;
-      }
-
-      #repo-author {
-        line-height: 40px;
-        white-space: nowrap;
-        vertical-align: top;
-        display: flex;
-      }
-
-      #header .avatar {
-        width: 40px;
-        height: 40px;
-        border-radius: 4px;
-        margin-right: 8px;
-      }
-
-      #info-download {
-        max-width: 270px;
-        padding: 12px 16px;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        white-space: nowrap;
-        background: white;
-        border-bottom: 1px solid #ededed;
-      }
-
-      #info-download h3 {
-        margin-top: 0;
-        margin-bottom: 4px;
-        color: var(--theme-blue-grey);
-      }
-
-      #info-download-command {
-        border: 0;
-        color: var(--theme-font-color);
-        display: block;
-        font-family: var(--monospace-font);
-        font-size: 12px;
-        outline: 0;
-        padding: 4px 0;
-        width: 100%;
-      }
-
-      #info-stats {
-        display: flex;
-        flex: 1 0 200px;
-        justify-content: space-between;
-        padding-right: 16px;
-        color: #9eadbb;
-      }
-
-      #info-stats div {
-        display: flex;
-        align-items: center;
-      }
-
-      #info-stats svg {
-        width: 24px;
-        height: 24px;
-        margin-right: 5px;
-      }
-
-      .octicon-star {
-        color: #f3b70b;
-      }
-
-      #info-view-github {
-        display: flex;
-        border-top: 0;
-        border-top-left-radius: 0;
-        border-top-right-radius: 0;
-        padding: 16px;
-        font-weight: 600;
-      }
-
-      #info-view-github svg {
-        width: 24px;
-        height: 24px;
-        fill: var(--syntax-bg);
-        margin-right: 16px;
-      }
-
-      #info-contributors {
-        flex: 0 0 270px !important;
-      }
-
       #info-dependencies {
         line-height: 32px;
       }
@@ -214,86 +103,9 @@
         display: none;
       }
 
-      #info-body {
-        display: flex;
-        background: hsl(0, 0%, 99%);
-        transition: height 200ms cubic-bezier(0, 0, 0.2, 1);
-        overflow: hidden;
-        height: 167px;
-      }
-
-      #info-body h3 {
-        margin-bottom: 0;
-      }
-
-      #info-body[body-collapsed] {
-        height: 41px;
-        transition-delay: 75ms;
-      }
-
-      #info-body contributors-list, #info-body activity-graph {
-        display: block;
-        margin-top: 16px;
-        transition: opacity 300ms 50ms cubic-bezier(0, 0, 0.2, 1);
-      }
-
-      #info-body[body-collapsed] contributors-list,
-      #info-body[body-collapsed] activity-graph {
-        opacity: 0;
-        transition-delay: 0ms;
-      }
-
-      #info-footer {
-        text-transform: uppercase;
-        font-weight: 600;
-        font-size: 14px;
-        height: 44px;
-        display: flex;
-        padding: 0 !important;
-      }
-
-      #info-license {
-        flex: 0 0 auto;
-      }
-
-      #info-license, #info-tags {
-        padding: 10px 16px;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-        max-width: calc(100% - 55px);
-        overflow: hidden;
-      }
-
-      #info-tags {
-        flex-grow: 1;
-      }
-
-      #info-tags a {
-        margin-right: 16px;
-      }
-
-      #info-footer h3 {
-        display: inline;
-        margin-right: 12px;
-      }
-
-      #expand-collapse {
-        padding: 12px 16px;
-        height: 100%;
-        border-left: 1px solid #ededed;
-        text-align: center;
-        cursor: pointer;
-        background: hsl(0, 0%, 99%);;
-      }
-
-      #expand-collapse svg {
-        width: 16px;
-        height: 16px;
-      }
-
       /* Sidebar */
-      .body > .sidebar > div {
-        margin-bottom: 40px;
+      .body > .sidebar > * {
+        margin-bottom: 24px;
       }
 
       #sidebar-spinner {
@@ -411,6 +223,11 @@
       @media (max-width: 500px) {
         #title {
           margin-left: 16px;
+          display: flex;
+        }
+
+        .sidebar {
+          margin: 0 16px;
         }
 
         h1.page-title {
@@ -420,33 +237,6 @@
           overflow: hidden;
           white-space: nowrap;
           max-width: calc(100% - 120px);
-        }
-
-        #header-main {
-          margin: 0 16px;
-          padding: 0;
-        }
-
-        #info-header {
-          flex-wrap: wrap;
-        }
-
-        #github-mobile-link {
-          margin-left: 8px;
-        }
-
-        #github-mobile-link svg {
-          width: 22px;
-          fill: var(--theme-black);
-        }
-
-        #info-stats {
-          margin-top: 8px;
-        }
-
-        #info-body, #info-download, #info-view-github,
-        #info-footer, #info-header h3, #info-dependencies {
-          display: none;
         }
 
         #demo-dialog {
@@ -491,28 +281,20 @@
 
     <div id="container">
 
+      <div id="title" class="mobile-only">
+        <h1 class="page-title">[[repo]]</h1>
+        <div id="version-sha">[[data.version]]</div>
+      </div>
+      <h2 class="page-subtitle mobile-only">[[data.description]] <a title="Home page link" href="[[data.homepage]]" hidden$="[[_redundantLink(data.homepage)]]">[[data.homepage]]</a></h2>
+
       <div class="body">
         <!-- Repository contents sidebar -->
         <div class="sidebar">
           <github-info data="[[data]]" class="box"></github-info>
-          <div class="box">
-            <div id="info-download">
-              <h3>Download</h3>
-              <input id="info-download-command" title="Download command" readonly value="bower i [[owner]]/[[repo]] --save" on-tap="_selectAllInfoDownload"/>
-            </div>
-            <a id="info-view-github" href="https://github.com/[[owner]]/[[repo]]" target="_blank">
-              <svg viewBox="0 0 100 100"><use xlink:href="/sprite.octicons.svg#mark-github"></use></svg>
-              <div>View on GitHub</div>
-            </a>
-          </div>
-
-          <a href="/publish/[[owner]]/[[repo]]" class="soft-button" hidden$="[[!_isPreview(route.prefix)]]">Publish</a>
-
-          <h1 hidden$="[[!_hasRepoContents]]">Repository contents</h1>
 
           <spinner-lite id="sidebar-spinner"></spinner-lite>
 
-          <div class="sidebar-nav box loader" role="navigation" collapse$="[[_shouldCollapseNav(bundledElements)]]" loading$="[[!docs]]" hidden$="[[!_hasRepoContents]]">
+          <div class="sidebar-nav box loader" role="navigation" collapse$="[[_shouldCollapseNav(bundledElements)]]" loading$="[[!docs]]">
             <a href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]">Overview</a>
 
             <template is="dom-repeat" items="[[dupedDemos]]" as="demo">
@@ -538,6 +320,13 @@
                 </template>
               </div>
             </template>
+          </div>
+
+          <div id="star-button" class="box" on-click="_authenticateStar" title="Star this repository" starred$="[[_repoStarred]]">
+            <svg class="desktop-only" viewBox="0 0 100 100">
+              <use xlink:href="/sprite.octicons.svg#star"></use>
+            </svg>
+            <div><div>Star on GitHub</div></div>
           </div>
 
           <div class="loader" loading$="[[!docs]]" hidden$="[[!collections.count]]">
@@ -566,18 +355,13 @@
                 </template>
               </div>
             </template>
-            <a id="report-link" class="soft-button desktop-only" href="https://github.com/webcomponents/beta/issues/new?title=Remove%20element%20[[owner]]/[[repo]]&body=This%20element%20should%20be%20removed%20because...&labels=User%20reports">
-              Flag element
-            </a>
           </div>
         </div>
 
         <!-- Main content pane -->
         <div id="main-content" class="main-content">
+
           <div id="title">
-            <svg id="star" class="desktop-only" viewBox="0 0 100 100" class="octicon octicon-star" on-click="_authenticateStar" title="Star this repository" starred$="[[_repoStarred]]">
-              <use xlink:href="/sprite.octicons.svg#star"></use>
-            </svg>
             <h1 class="page-title">[[repo]]</h1>
             <template is="dom-if" if="[[!_contains(data.versions, data.version)]]">
               <div id="version-sha">[[data.version]]</div>
@@ -589,9 +373,6 @@
                 </template>
               </select>
             </template>
-            <a id="github-mobile-link" href="https://github.com/[[owner]]/[[repo]]" class="mobile-only">
-              <svg viewBox="0 0 100 100"><use xlink:href="/sprite.octicons.svg#mark-github"></use></svg>
-            </a>
           </div>
           <h2 class="page-subtitle">[[data.description]] <a title="Home page link" href="[[data.homepage]]" hidden$="[[_redundantLink(data.homepage)]]">[[data.homepage]]</a></h2>
 
@@ -637,11 +418,6 @@
         baseUrls: Object,
 
         queryParams: Object,
-
-        _infoBodyCollapsed: {
-          type: Boolean,
-          value: true,
-        },
       },
 
       observers: [
@@ -951,14 +727,6 @@
         return ['Last updated ', months, ' month', this._s(months), ' ago'].join('');
       },
 
-      _toggleExpand: function() {
-        this._infoBodyCollapsed = !this._infoBodyCollapsed;
-      },
-
-      _searchTag: function(event) {
-        this.fire('triggerSearch', {query: event.target.tag});
-      },
-
       _or: function(a, b) {
         return a || b;
       },
@@ -974,20 +742,12 @@
         }
       },
 
-      _dpr: function(value) {
-        return value * (window.devicePixelRatio || 1);
-      },
-
       _s: function(n) {
         return n == 1 ? '' : 's';
       },
 
       _shouldCollapseNav: function(elements) {
         return elements && elements.length > 5;
-      },
-
-      _isPreview: function(prefix) {
-        return prefix == '/preview';
       },
 
       _authenticateStar: function() {
@@ -1037,10 +797,6 @@
 
         xhr.open('POST', this.baseUrls.api + '/api/star/' + this.owner + '/' + this.repo + '?code=' + this.queryParams.code);
         xhr.send();
-      },
-
-      _selectAllInfoDownload: function(event) {
-        event.currentTarget.select();
       },
 
       _docTitle: function(subElement, descriptor) {

--- a/client/src/catalog-styles.html
+++ b/client/src/catalog-styles.html
@@ -89,13 +89,13 @@
         flex: 10 0 270px;
         max-width: calc(100% - 270px);
         min-width: 300px;
-        margin-right: 40px;
       }
 
       .sidebar {
         flex: 0 0 270px;
         order: 2;
         width: 270px;
+        margin-left: 40px;
       }
 
       .sidebar h3 {
@@ -164,7 +164,6 @@
         .main-content {
           max-width: 100%;
           padding: 0 16px;
-          margin-right: 0;
         }
 
         .sidebar {

--- a/client/src/contributors-list.html
+++ b/client/src/contributors-list.html
@@ -37,7 +37,7 @@
     </style>
 
     <div id="container">
-      <template is="dom-repeat" items="[[_contributors]]"><img class="avatar" src="[[item.avatar_url]]&s=60" role="presentation"></template>
+      <template is="dom-repeat" items="[[_contributors]]"><img class="avatar" src="[[item.avatar_url]]&s=60" role="presentation" title$="[[item.login]]"></template>
       <template is="dom-if" if="[[_overflowCount]]">
         <div class="overflow">+[[_overflowCount]]</div>
       </template>

--- a/client/src/contributors-list.html
+++ b/client/src/contributors-list.html
@@ -4,44 +4,47 @@
   <template>
     <style>
       #container {
-        position: relative;
-        max-height: 110px;
-        line-height: 0;
+        max-height: 112px;
+        display: flex;
+        flex-wrap: wrap;
       }
 
-      img.avatar {
+      #container > * {
         border-radius: 4px;
-        width: 30px;
-        height: 30px;
-        margin: 0 10px 10px 0;
+        width: 32px;
+        height: 32px;
+        margin: 0 7px 7px 0;
+        animation: fade 150ms backwards cubic-bezier(0, 0, 0.2, 1);
       }
 
-      img.avatar:nth-of-type(7n) {
-        margin-right: 0;
+      @keyframes fade {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
       }
 
       div.overflow {
-        position: absolute;
-        right: 0;
-        bottom: 0;
-        width: 30px;
-        height: 30px;
-        border-radius: 4px;
-        display: flex;
+        display: inline-flex;
         align-items: center;
         justify-content: center;
         color: white;
         background: hsla(0, 0%, 0%, 0.6);
         font-weight: 600;
+        animation-delay: 170ms !important;
       }
     </style>
 
     <div id="container">
-      <template is="dom-repeat" items="[[_contributors]]"><img class="avatar" src="[[item.avatar_url]]&s=60" role="presentation" title$="[[item.login]]"></template>
+      <template is="dom-repeat" items="[[_contributors]]">
+        <img class="avatar" src="[[item.avatar_url]]&s=64" role="presentation" title$="[[item.login]]" style="animation-delay: [[_computeDelay(index)]]">
+      </template>
       <template is="dom-if" if="[[_overflowCount]]">
         <div class="overflow">+[[_overflowCount]]</div>
       </template>
-    <div>
+    </div>
   </template>
 
   <script>
@@ -63,8 +66,12 @@
           this._overflowCount = 0;
           return;
         }
-        this._overflowCount = Math.max(contributors.length - 21, 0);
-        this._contributors = contributors.slice(0, 21);
+        this._overflowCount = Math.max(contributors.length - 18, 0);
+        this._contributors = contributors.slice(0, 17);
+      },
+
+      _computeDelay: function(i) {
+        return i * 10 + 'ms';
       },
 
     });

--- a/client/src/github-info.html
+++ b/client/src/github-info.html
@@ -1,0 +1,251 @@
+<link rel="import" href="../bower_components/polymer/polymer.html">
+
+<dom-module id="github-info">
+  <template>
+    <style>
+      :host {
+        display: flex;
+        flex-direction: column;
+        color: var(--theme-blue-grey);
+      }
+
+      section {
+        padding: 12px 16px;
+      }
+
+      section:not(:first-child) {
+        border-top: 1px solid #ededed;
+      }
+
+      section.collapsed {
+        background: hsl(0, 0%, 99%);
+      }
+
+      section.expanded {
+        display: none;
+        flex-direction: column;
+      }
+
+      section.expanded h3:not(:first-of-type) {
+        margin: 16px 0 8px;
+      }
+
+      #container[expanded] section.collapsed {
+        display: none;
+      }
+
+      #container[expanded] section.expanded {
+        display: flex;
+      }
+
+      a {
+        color: var(--theme-blue-small);
+        text-decoration: none;
+      }
+
+      svg {
+        display: inline-block;
+        vertical-align: text-top;
+        fill: currentColor;
+      }
+
+      h3 {
+        text-transform: uppercase;
+        font-size: 13px;
+        line-height: 16px;
+        font-weight: 600;
+        margin: 0;
+      }
+
+      section.collapsible h3 {
+        display: inline;
+      }
+
+      .avatar {
+        width: 40px;
+        height: 40px;
+        border-radius: 4px;
+        margin-right: 8px;
+      }
+
+      #author {
+        line-height: 40px;
+        white-space: nowrap;
+        vertical-align: top;
+        display: flex;
+      }
+
+      #stats {
+        display: flex;
+        justify-content: space-between;
+        padding-right: 16px;
+        color: #9eadbb;
+      }
+
+      #stats div {
+        display: flex;
+        align-items: center;
+      }
+
+      #stats svg {
+        width: 24px;
+        height: 24px;
+        margin-right: 5px;
+      }
+
+      .octicon-star {
+        color: #f3b70b;
+      }
+
+      #tags {
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 14px;
+      }
+
+      #download-command {
+        border: 0;
+        color: var(--theme-font-color);
+        display: block;
+        font-family: var(--monospace-font);
+        font-size: 12px;
+        outline: 0;
+        padding: 4px 0;
+      }
+
+      #info-view-github {
+        display: flex;
+        border-top: 0;
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        padding: 16px;
+        font-weight: 600;
+      }
+
+      #info-view-github svg {
+        width: 24px;
+        height: 24px;
+        fill: var(--syntax-bg);
+        margin-right: 16px;
+      }
+
+
+
+    </style>
+
+    <template is="dom-if" if="[[data]]">
+      <div id="container" expanded$="[[_expanded]]">
+        <section id="author">
+          <img class="avatar" src="[[data.avatar_url]]&s=[[_dpr(40)]]" role="presentation">
+          <span>by <a href="/author/[[data.owner]]">[[data.owner]]</a></span>
+        </section>
+
+        <section id="stats">
+          <div title="[[data.stars]] users starred this repository">
+            <svg viewBox="0 0 100 100" class="octicon octicon-star">
+             <use xlink:href="/sprite.octicons.svg#star"></use>
+            </svg>
+            [[data.stars]]
+          </div>
+          <div title="[[data.forks]] users forked this repository">
+            <svg viewBox="0 0 100 100" class="octicon octicon-repo-forked">
+             <use xlink:href="/sprite.octicons.svg#repo-forked"></use>
+            </svg>
+            [[data.forks]]
+          </div>
+          <div title="[[data.subscribers]] users are watching this repository">
+            <svg viewBox="0 0 100 100" class="octicon octicon-eye">
+             <use xlink:href="/sprite.octicons.svg#eye"></use>
+            </svg>
+            [[data.subscribers]]
+          </div>
+          <div title="[[data.open_issues]] open issues and pull requests in this repository">
+            <svg viewBox="0 0 100 100" class="octicon octicon-issue-opened">
+             <use xlink:href="/sprite.octicons.svg#issue-opened"></use>
+            </svg>
+            [[data.open_issues]]
+          </div>
+        </section>
+
+        <section class="collapsed" on-tap="_toggleExpand">
+          <h3>
+            License
+            <a href="https://spdx.org/licenses/[[data.spdx_identifier]]" target="_blank">[[data.spdx_identifier]]</a>, 
+            [[data.contributors.length]] contributor[[_s(data.contributors.length)]], 
+            [[_lastUpdated(data.activity)]], 
+            [[data.bower.keywords.length]] tags
+          </h3>
+        </section>
+
+        <section class="expanded">
+          <h3 class="always-visible">License
+            <a href="https://spdx.org/licenses/[[data.spdx_identifier]]" target="_blank">[[data.spdx_identifier]]</a>
+          </h3>
+          <h3 class="always-visible">[[data.contributors.length]] contributor[[_s(data.contributors.length)]]</h3>
+          <contributors-list contributors="[[data.contributors]]"></contributors-list>
+          <h3 class="always-visible">[[_lastUpdated(data.activity)]]</h3>
+          <activity-graph activity="[[data.activity]]"></activity-graph>
+          <h3>Tags</h3>
+          <div id="tags">
+            <template is="dom-repeat" items="[[data.bower.keywords]]">
+              <a href="#" tag="[[item]]" on-click="_searchTag">[[item]]</a>
+            </template>
+          </div>
+
+          <h3>Download</h3>
+          <input id="download-command" title="Download command" readonly value="bower i [[data.owner]]/[[data.repo]] --save" on-tap="_selectAllInfoDownload"/>
+          <a id="info-view-github" href="https://github.com/[[data.owner]]/[[data.repo]]" target="_blank">
+            <svg viewBox="0 0 100 100"><use xlink:href="/sprite.octicons.svg#mark-github"></use></svg>
+            <div>View on GitHub</div>
+          </a>
+        </section>
+      </div>
+    </template>
+  </template>
+
+  <script>
+    Polymer({
+
+      is: 'github-info',
+
+      properties: {
+        data: Object,
+      },
+
+      _dpr: function(value) {
+        return value * (window.devicePixelRatio || 1);
+      },
+
+      _s: function(n) {
+        return n == 1 ? '' : 's';
+      },
+
+      _lastUpdated: function(activity) {
+        if (!activity)
+          return;
+        var i = 0;
+        for (i = 0; i < activity.length; i++) {
+          if (activity[activity.length - 1 - i])
+            break;
+        }
+        if (i == 0)
+          return 'Updated recently';
+        if (i == activity.length)
+          return '';
+        if (i < 8)
+          return ['Last updated ', i, ' week', this._s(i), ' ago'].join('');
+        var months = Math.round(i / 4);
+        return ['Last updated ', months, ' month', this._s(months), ' ago'].join('');
+      },
+
+      _toggleExpand: function() {
+        this._expanded = true;
+      },
+
+      _selectAllInfoDownload: function(event) {
+        event.currentTarget.select();
+      },
+
+    });
+  </script>
+</dom-module>

--- a/client/src/github-info.html
+++ b/client/src/github-info.html
@@ -4,21 +4,42 @@
   <template>
     <style>
       :host {
-        display: flex;
-        flex-direction: column;
+        display: block;
         color: var(--theme-blue-grey);
       }
 
       section {
         padding: 12px 16px;
+        border-top: 1px solid #ededed;
+        display: flex;
+        flex: 1 0;
       }
 
-      section:not(:first-child) {
-        border-top: 1px solid #ededed;
+      #container > section:first-child {
+        border-top: none;
       }
 
       section.collapsed {
-        background: hsl(0, 0%, 99%);
+        display: flex;
+        cursor: pointer;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      section.dark {
+        background: hsl(0, 0%, 98%);
+      }
+
+      #plus-button, #minus-button {
+        width: 16px;
+        height: 16px;
+        margin-left: 16px;
+        flex: 0 0 16px;
+      }
+
+      #container:not([expanded]) #minus-button,
+      #container[expanded] #plus-button {
+        display: none;
       }
 
       section.expanded {
@@ -26,16 +47,26 @@
         flex-direction: column;
       }
 
-      section.expanded h3:not(:first-of-type) {
-        margin: 16px 0 8px;
+      section.expanded h3 {
+        margin-bottom: 8px;
       }
 
-      #container[expanded] section.collapsed {
-        display: none;
+      section.expanded h3:not(:first-of-type) {
+        margin-top: 16px;
       }
 
       #container[expanded] section.expanded {
         display: flex;
+        animation: fade 300ms cubic-bezier(0, 0, 0.2, 1);
+      }
+
+      @keyframes fade {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
       }
 
       a {
@@ -57,10 +88,6 @@
         margin: 0;
       }
 
-      section.collapsible h3 {
-        display: inline;
-      }
-
       .avatar {
         width: 40px;
         height: 40px;
@@ -80,6 +107,9 @@
         justify-content: space-between;
         padding-right: 16px;
         color: #9eadbb;
+        border-top: none;
+        padding-top: 0;
+        padding-bottom: 16px;
       }
 
       #stats div {
@@ -110,27 +140,26 @@
         font-family: var(--monospace-font);
         font-size: 12px;
         outline: 0;
-        padding: 4px 0;
       }
 
-      #info-view-github {
-        display: flex;
-        border-top: 0;
-        border-top-left-radius: 0;
-        border-top-right-radius: 0;
-        padding: 16px;
+      #container > a section {
         font-weight: 600;
+        flex-direction: row;
+        font-weight: 600;
+        justify-content: center;
+        padding: 16px;
       }
 
-      #info-view-github svg {
+      #github-link > a section {
+        margin-left: -12px;
+      }
+
+      #github-link svg {
         width: 24px;
         height: 24px;
-        fill: var(--syntax-bg);
+        fill: black;
         margin-right: 16px;
       }
-
-
-
     </style>
 
     <template is="dom-if" if="[[data]]">
@@ -142,50 +171,54 @@
 
         <section id="stats">
           <div title="[[data.stars]] users starred this repository">
-            <svg viewBox="0 0 100 100" class="octicon octicon-star">
+            <svg viewBox="0 0 100 100" class="octicon-star">
              <use xlink:href="/sprite.octicons.svg#star"></use>
             </svg>
             [[data.stars]]
           </div>
           <div title="[[data.forks]] users forked this repository">
-            <svg viewBox="0 0 100 100" class="octicon octicon-repo-forked">
+            <svg viewBox="0 0 100 100">
              <use xlink:href="/sprite.octicons.svg#repo-forked"></use>
             </svg>
             [[data.forks]]
           </div>
           <div title="[[data.subscribers]] users are watching this repository">
-            <svg viewBox="0 0 100 100" class="octicon octicon-eye">
+            <svg viewBox="0 0 100 100">
              <use xlink:href="/sprite.octicons.svg#eye"></use>
             </svg>
             [[data.subscribers]]
           </div>
           <div title="[[data.open_issues]] open issues and pull requests in this repository">
-            <svg viewBox="0 0 100 100" class="octicon octicon-issue-opened">
+            <svg viewBox="0 0 100 100">
              <use xlink:href="/sprite.octicons.svg#issue-opened"></use>
             </svg>
             [[data.open_issues]]
           </div>
         </section>
 
-        <section class="collapsed" on-tap="_toggleExpand">
+        <section class="collapsed dark" on-tap="_toggleExpand">
           <h3>
-            License
+            Licensed under 
             <a href="https://spdx.org/licenses/[[data.spdx_identifier]]" target="_blank">[[data.spdx_identifier]]</a>, 
-            [[data.contributors.length]] contributor[[_s(data.contributors.length)]], 
-            [[_lastUpdated(data.activity)]], 
-            [[data.bower.keywords.length]] tags
+            [[_lastUpdated(data.activity)]]
           </h3>
+
+          <svg id="plus-button" viewBox="0 0 100 100">
+            <use xlink:href="/sprite.octicons.svg#plus"></use>
+          </svg>
+          <svg id="minus-button" viewBox="0 0 100 100">
+            <use xlink:href="/sprite.octicons.svg#dash"></use>
+          </svg>
         </section>
 
-        <section class="expanded">
-          <h3 class="always-visible">License
-            <a href="https://spdx.org/licenses/[[data.spdx_identifier]]" target="_blank">[[data.spdx_identifier]]</a>
-          </h3>
-          <h3 class="always-visible">[[data.contributors.length]] contributor[[_s(data.contributors.length)]]</h3>
+        <section class="expanded dark">
+          <h3>[[data.contributors.length]] contributor[[_s(data.contributors.length)]]</h3>
           <contributors-list contributors="[[data.contributors]]"></contributors-list>
-          <h3 class="always-visible">[[_lastUpdated(data.activity)]]</h3>
+
+          <h3>[[_lastUpdated(data.activity)]]</h3>
           <activity-graph activity="[[data.activity]]"></activity-graph>
-          <h3>Tags</h3>
+
+          <h3 hidden$="[[!data.bower.keywords.length]]">Tags</h3>
           <div id="tags">
             <template is="dom-repeat" items="[[data.bower.keywords]]">
               <a href="#" tag="[[item]]" on-click="_searchTag">[[item]]</a>
@@ -193,12 +226,19 @@
           </div>
 
           <h3>Download</h3>
-          <input id="download-command" title="Download command" readonly value="bower i [[data.owner]]/[[data.repo]] --save" on-tap="_selectAllInfoDownload"/>
-          <a id="info-view-github" href="https://github.com/[[data.owner]]/[[data.repo]]" target="_blank">
+          <div id="download-command" title="Download command" value="" on-tap="_selectAllInfoDownload">bower i [[data.owner]]/[[data.repo]] --save</div>
+        </section>
+
+        <a id="github-link" href="https://github.com/[[data.owner]]/[[data.repo]]" target="_blank">
+          <section class="expanded">
             <svg viewBox="0 0 100 100"><use xlink:href="/sprite.octicons.svg#mark-github"></use></svg>
             <div>View on GitHub</div>
-          </a>
-        </section>
+          </section>
+        </a>
+
+        <a href="https://github.com/webcomponents/beta/issues/new?title=Remove%20element%20[[owner]]/[[repo]]&body=This%20element%20should%20be%20removed%20because...&labels=User%20reports">
+          <section class="expanded">Flag element</section>
+        </a>
       </div>
     </template>
   </template>
@@ -231,7 +271,7 @@
         if (i == 0)
           return 'Updated recently';
         if (i == activity.length)
-          return '';
+          return 'Last updated unknown';
         if (i < 8)
           return ['Last updated ', i, ' week', this._s(i), ' ago'].join('');
         var months = Math.round(i / 4);
@@ -239,11 +279,25 @@
       },
 
       _toggleExpand: function() {
-        this._expanded = true;
+        this._expanded = !this._expanded;
       },
 
       _selectAllInfoDownload: function(event) {
-        event.currentTarget.select();
+        var range;
+        if (document.body.createTextRange) {
+          range = document.body.createTextRange();
+          range.moveToElementText(event.currentTarget);
+          range.select();
+        } else if (window.getSelection) {
+          range = document.createRange();
+          range.selectNodeContents(event.currentTarget);
+          window.getSelection().removeAllRanges();
+          window.getSelection().addRange(range);
+        }
+      },
+
+      _searchTag: function(event) {
+        this.fire('triggerSearch', {query: event.target.tag});
       },
 
     });

--- a/client/src/github-info.html
+++ b/client/src/github-info.html
@@ -271,7 +271,7 @@
         if (i == 0)
           return 'Updated recently';
         if (i == activity.length)
-          return 'Last updated unknown';
+          return 'Last update unknown';
         if (i < 8)
           return ['Last updated ', i, ' week', this._s(i), ' ago'].join('');
         var months = Math.round(i / 4);


### PR DESCRIPTION
Implements #840 
 * Collapsible GitHub info section
 * Compact view of GitHub info
 * Star on GitHub button broken out
 * Moves sidebar from right to left

![image](https://cloud.githubusercontent.com/assets/787668/22450563/a68e65c0-e7bb-11e6-8ad3-28b9b65efd75.png)
![image](https://cloud.githubusercontent.com/assets/787668/22450568/ab95c5fe-e7bb-11e6-9ac3-0848c19702c3.png)
![image](https://cloud.githubusercontent.com/assets/787668/22450575/b67a50a2-e7bb-11e6-857c-d74888c7c4bf.png)

