### PR TITLE
Use debouncer microtask to guarantee completed changes

### DIFF
--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -549,7 +549,7 @@
         // Generate requests
         if (!this.data || this._currentOwner != this.owner || this._currentRepo != this.repo || this._currentVersionRoute != this.versionRoute) {
           // Trigger a microtask to ensure change notifications are completed.
-          this.debounce('update', this._updatePath);
+          this.debounce('_updatePath', this._updatePath);
         }
 
         this._updateDescriptor();

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -548,16 +548,21 @@
 
         // Generate requests
         if (!this.data || this._currentOwner != this.owner || this._currentRepo != this.repo || this._currentVersionRoute != this.versionRoute) {
-          this._currentOwner = this.owner;
-          this._currentRepo = this.repo;
-          this._currentVersionRoute = this.versionRoute;
-          this.docs = null;
-          this.$.metaAjax.generateRequest();
-          this.$.docsAjax.generateRequest();
-          this.$.collectionsAjax.generateRequest();
+          // Trigger a microtask to ensure change notifications are completed.
+          this.debounce('update', this._updatePath);
         }
 
         this._updateDescriptor();
+      },
+
+      _updatePath: function() {
+        this._currentOwner = this.owner;
+        this._currentRepo = this.repo;
+        this._currentVersionRoute = this.versionRoute;
+        this.docs = null;
+        this.$.metaAjax.generateRequest();
+        this.$.docsAjax.generateRequest();
+        this.$.collectionsAjax.generateRequest();
       },
 
       _demoChanged: function(demo, visible) {

--- a/client/test/catalog-element.html
+++ b/client/test/catalog-element.html
@@ -79,6 +79,7 @@
       elementPage.baseUrls = {api: '', userContent: ''};
       elementPage.route = {path: '/owner/repo', prefix: '/element'};
       elementPage.setAttribute('visible', '');
+      elementPage.flushDebouncer('_updatePath');
       server.respond();
       elementPage.$.metaAjax.addEventListener('response', function() {
         flush(function() {
@@ -95,6 +96,7 @@
       elementPage.baseUrls = {api: '', userContent: ''};
       elementPage.route = {path: '/owner/repo', prefix: '/element'};
       elementPage.setAttribute('visible', '');
+      elementPage.flushDebouncer('_updatePath');
       server.respond();
       assert(!elementPage._isStarred(), 'should not be starred');
       elementPage._setStarred(false);
@@ -107,6 +109,7 @@
       elementPage.route = {path: '/owner/repo', prefix: '/element'};
       elementPage.setAttribute('visible', '');
       elementPage.queryParams = {code: 'fakeCode'};
+      elementPage.flushDebouncer('_updatePath');
       server.respond();
 
       elementPage.$.metaAjax.addEventListener('response', function() {


### PR DESCRIPTION
Fixes #851

This was caused by the ordering of changes:
 * `visible` triggered first with the previous route
 * A new request was generated since we have no cached data (errored)
 * Route then changed to new route
 * By then, the page had already changed back to the error page.

By using a microtask, it guarantees that all change notifications have been completed before generating the requests. Ordering of the change notifications is no longer important.