### PR TITLE
Show view on GitHub permanently and move download up

### DIFF
--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -29,22 +29,37 @@
         margin-bottom: 0;
       }
 
-      #star-button {
+      #github-action-group > * {
         display: flex;
         align-items: center;
-        padding: 12px 16px;
+        padding: 16px;
         font-weight: 600;
         cursor: pointer;
       }
 
-      #star-button svg {
+      #github-action-group > *:hover {
+        background: hsl(0, 0%, 98%);
+      }
+
+      #github-action-group svg {
         width: 24px;
         height: 24px;
+        margin-right: 12px;
+      }
+
+      #github-view-button svg {
+        fill: hsl(0, 0%, 20%);
+      }
+
+      #star-button {
+        line-height: 1em;
+      }
+
+      #star-button svg {
         stroke: hsl(0, 0%, 45%);
         fill: transparent;
-        margin-right: 12px;
         cursor: pointer;
-        transition: fill 150ms, stroke 150ms;
+        transition: fill 150ms, stroke 50ms;
       }
 
       #star-button:hover svg, #star-button[starred] svg {
@@ -322,11 +337,17 @@
             </template>
           </div>
 
-          <div id="star-button" class="box" on-click="_authenticateStar" title="Star this repository" starred$="[[_repoStarred]]">
-            <svg viewBox="0 0 100 100">
-              <use xlink:href="/sprite.octicons.svg#star"></use>
-            </svg>
-            <div><div>Star on GitHub</div></div>
+          <div id="github-action-group" class="box">
+            <a id="github-view-button" href="https://github.com/[[owner]]/[[repo]]" target="_blank">
+              <svg viewBox="0 0 100 100"><use xlink:href="/sprite.octicons.svg#mark-github"></use></svg>
+              <div>View on GitHub</div>
+            </a>
+            <a id="star-button" on-click="_authenticateStar" title="Star this repository" starred$="[[_repoStarred]]">
+              <svg viewBox="0 0 100 100">
+                <use xlink:href="/sprite.octicons.svg#star"></use>
+              </svg>
+              <div><div>Star on GitHub</div></div>
+            </a>
           </div>
 
           <div class="loader" loading$="[[!docs]]" hidden$="[[!collections.count]]">

--- a/client/src/github-info.html
+++ b/client/src/github-info.html
@@ -201,7 +201,7 @@
             Licensed under 
             <a href="https://spdx.org/licenses/[[data.spdx_identifier]]" target="_blank">[[data.spdx_identifier]]</a>, 
             [[_lastUpdated(data.activity)]], 
-            installed via <a>Bower</a> & sourced from <a>GitHub</a>
+            & installed via <a>Bower</a>
           </h3>
 
           <svg id="plus-button" viewBox="0 0 100 100">
@@ -213,6 +213,9 @@
         </section>
 
         <section class="expanded dark">
+          <h3>Download</h3>
+          <div id="download-command" title="Download command" on-tap="_selectAllInfoDownload">bower install --save [[data.owner]]/[[data.repo]]</div>
+
           <h3>[[data.contributors.length]] contributor[[_s(data.contributors.length)]]</h3>
           <contributors-list contributors="[[data.contributors]]"></contributors-list>
 
@@ -225,17 +228,7 @@
               <a href="#" tag="[[item]]" on-click="_searchTag">[[item]]</a>
             </template>
           </div>
-
-          <h3>Download</h3>
-          <div id="download-command" title="Download command" value="" on-tap="_selectAllInfoDownload">bower install --save [[data.owner]]/[[data.repo]]</div>
         </section>
-
-        <a id="github-link" href="https://github.com/[[data.owner]]/[[data.repo]]" target="_blank">
-          <section class="expanded">
-            <svg viewBox="0 0 100 100"><use xlink:href="/sprite.octicons.svg#mark-github"></use></svg>
-            <div>View on GitHub</div>
-          </section>
-        </a>
 
         <a href="https://github.com/webcomponents/beta/issues/new?title=Remove%20element%20[[owner]]/[[repo]]&body=This%20element%20should%20be%20removed%20because...&labels=User%20reports">
           <section class="expanded">Flag element</section>


### PR DESCRIPTION
Addresses comments on how often "view on GitHub" is used. This has moved to be permanently visible, but still below the key navigation element, meaning vertical space isn't too much of an issue here. Download has moved to the top in the collapsible section.

![image](https://cloud.githubusercontent.com/assets/787668/22719652/8fcbda6c-edfa-11e6-8196-8775d46f889b.png)
![image](https://cloud.githubusercontent.com/assets/787668/22719642/89429a50-edfa-11e6-8d8c-2d1b0770c9bd.png)

