### PR TITLE
Refactor analyzer code to use updated versions

### DIFF
--- a/analysis/package.json
+++ b/analysis/package.json
@@ -3,16 +3,16 @@
   "version": "1.0.1",
   "private": true,
   "dependencies": {
-    "@google-cloud/pubsub": "0.1.1",
-    "@google/cloud-debug": "0.8.4",
-    "@google/cloud-trace": "0.5.7",
+    "@google-cloud/debug-agent": "^0.10.2",
+    "@google-cloud/pubsub": "^0.8.2",
+    "@google/cloud-trace": "^0.6.2",
     "body-parser": "1.14.2",
     "bower": "1.7.9",
     "command-line-args": "3.0.1",
     "express": "4.13.4",
     "hydrolysis": "1.24.1",
     "lockfile": "1.0.1",
-    "polymer-analyzer": "^2.0.0-alpha.21",
+    "polymer-analyzer": "2.0.0-alpha.30",
     "stream-buffers": "3.0.1"
   },
   "engines": {

--- a/analysis/package.json
+++ b/analysis/package.json
@@ -12,7 +12,7 @@
     "express": "4.13.4",
     "hydrolysis": "1.24.1",
     "lockfile": "1.0.1",
-    "polymer-analyzer": "2.0.0-alpha.30",
+    "polymer-analyzer": "2.0.0-alpha.31",
     "stream-buffers": "3.0.1"
   },
   "engines": {

--- a/analysis/package.json
+++ b/analysis/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "node src/main.js --responseTopic analysis-responses",
     "test": "npm run test-mocha",
-    "test-mocha": "mocha -R spec ./test/bower-test.js"
+    "test-mocha": "mocha -R spec ./test/*.js"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/analysis/src/analyzer.js
+++ b/analysis/src/analyzer.js
@@ -2,93 +2,39 @@
 
 const Ana = require('./ana_log');
 
-const PolymerAnalyzer = require('polymer-analyzer').Analyzer;
-const Element = require('polymer-analyzer/lib/model/model').Element;
+const Analyzer = require('polymer-analyzer').Analyzer;
+const Elements = require('polymer-analyzer/lib/elements-format');
+const generateAnalysis = require('polymer-analyzer/lib/generate-analysis').generateAnalysis;
+const Feature = require('polymer-analyzer/lib/model/model');
 const FSUrlLoader = require('polymer-analyzer/lib/url-loader/fs-url-loader').FSUrlLoader;
 const PackageUrlResolver = require('polymer-analyzer/lib/url-loader/package-url-resolver').PackageUrlResolver;
-const path = require('path');
 
-/**
- * @param {Object} obj - The object to strip properties from.
- * @param {Array.<string>} properties - An array of property names to remove.
- * @param {number} depth - The current depth of the recursion.
- */
-function removeProperties(obj, properties, depth) {
-  // Bail after 10 deep so that we don't blow the stack.
-  if (!properties || !obj || depth > 10) return;
-  if (typeof obj === 'object') {
-    for (var prop of properties) {
-      delete obj[prop];
-    }
-    Object.keys(obj).forEach(x => removeProperties(obj[x], properties, depth + 1));
-  } else if (Array.isArray(obj)) {
-    obj.forEach(val => removeProperties(val, properties, depth + 1));
-  }
-}
-
-function remove(obj) {
-  removeProperties(obj, ["scriptElement", "javascriptNode",
-      "observerNode", "astNode", "sourceRange", "domModule"], 0);
-}
-
-/**
- * Service for running Polymer Analyzer on the local machine.
- */
-class Analyzer {
-
-  /**
-   * Runs Polymer Analyzer against each main html file in the given list.
-   * Merges Element and Behavior key/values from each main html into one set each.
-   * Output looks like {elementsByTagName:{}, behaviorsByName:{}}.
-   * @param {Array.<string>} mainHtmlPaths - paths to mainHtml files
-   * @return {Promise.<Array.<Object>>} a promise, returning the element and behavior data.
-   */
-  analyze(mainHtmlPaths) {
-    /*
-     * Run Analyzis on given paths and extract relevant data. Failure is fine, we just ignore it.
-     */
+class AnalyzerRunner {
+  analyze(inputs) {
     return new Promise(resolve => {
-      Ana.log("analyzer/analyze", mainHtmlPaths);
-      var data = {
-        elementsByTagName: {},
-        behaviorsByName: {}
-      };
+      Ana.log('analyzer/analyze', inputs);
 
-      Promise.all(
-        mainHtmlPaths.map(mainHtmlPath => {
-          var analyzer = new PolymerAnalyzer({
-            urlLoader: new FSUrlLoader("/"),
-            urlResolver: new PackageUrlResolver(),
-          });
-
-          var dirName = path.dirname(mainHtmlPath);
-          var skipItem = item => path.relative(dirName, "/" + item.sourceRange.file).includes("..");
-
-          return analyzer.analyze(mainHtmlPath).then(document => {
-            var elements = document.getByKind('element');
-            elements.forEach(element => {
-              if (skipItem(element)) return;
-
-              data.elementsByTagName[element.tagName] = element;
-              remove(data.elementsByTagName[element.tagName])
-            });
-            var behaviors = document.getByKind('behavior');
-            behaviors.forEach(behavior => {
-              if (skipItem(behavior)) return;
-
-              data.behaviorsByName[behavior.className] = behavior;
-              remove(data.behaviorsByName[behavior.className])
-            });
-          }).catch(error => {
-            Ana.fail("analyzer/analyze", mainHtmlPath, error);
-          });
-        })
-      ).then(function() {
-        Ana.success("analyzer/analyze", mainHtmlPaths);
-        resolve(data);
+      const analyzer = new Analyzer({
+        urlLoader: new FSUrlLoader('/'),
+        urlResolver: new PackageUrlResolver(),
       });
+
+      const isInTests = /(\b|\/|\\)(test)(\/|\\)/;
+      const isNotTest = feature =>
+          feature.sourceRange != null && !isInTests.test(feature.sourceRange.file);
+
+      if (inputs == null || inputs.length === 0) {
+        analyzer.analyzePackage().then(function(_package) {
+          resolve(generateAnalysis(_package, '', isNotTest));
+        });
+      } else {
+        Promise.all(inputs.map((i) => analyzer.analyze(i))).then(function(documents) {
+          resolve(generateAnalysis(documents, '', isNotTest));
+        });
+      }
+
     });
   }
 }
 
-module.exports = Analyzer;
+module.exports = AnalyzerRunner;

--- a/analysis/src/analyzer.js
+++ b/analysis/src/analyzer.js
@@ -3,7 +3,7 @@
 const Ana = require('./ana_log');
 
 const Analyzer = require('polymer-analyzer').Analyzer;
-const Elements = require('polymer-analyzer/lib/elements-format');
+const Analysis = require('polymer-analyzer/lib/analysis-format');
 const generateAnalysis = require('polymer-analyzer/lib/generate-analysis').generateAnalysis;
 const Feature = require('polymer-analyzer/lib/model/model');
 const FSUrlLoader = require('polymer-analyzer/lib/url-loader/fs-url-loader').FSUrlLoader;

--- a/analysis/src/main.js
+++ b/analysis/src/main.js
@@ -7,7 +7,7 @@ if (process.env.NODE_ENV === 'production') {
 
 const Ana = require('./ana_log');
 const Analysis = require('./analysis');
-const PolymerAnalyzer = require('./analyzer');
+const AnalyzerRunner = require('./analyzer');
 const Bower = require('./bower');
 const Catalog = require('./catalog');
 const DebugCatalog = require('./debug_catalog');
@@ -50,7 +50,7 @@ function processTasks() {
   var analysis = new Analysis(
       new Bower(),
       new Hydrolysis(),
-      new PolymerAnalyzer(),
+      new AnalyzerRunner(),
       catalog);
 
   var locky = new Date().toString() + ".lock";

--- a/analysis/test/analyzer-test.js
+++ b/analysis/test/analyzer-test.js
@@ -1,0 +1,15 @@
+
+var expect = require('chai').expect;
+var path = require('path');
+
+var AnalyzerRunner = require('../src/analyzer');
+
+describe('AnalyzerRunner', function() {
+  it('is sensible', function() {
+    var analyzer = new AnalyzerRunner();
+    return analyzer.analyze([path.resolve(__dirname, '../../client/src/catalog-app.html')]).then(function(result) {
+      expect(result).to.exist;
+      expect(JSON.stringify(result)).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
 * Update Google Cloud dependencies to use non-deprecated NPM packages.
 * Use a newer version of polymer-analyzer
 * Refactor how analyzer is called based on polymer-analyzer updates
 * Add a simple test which analyzes a single element from `client/src`