### PR TITLE
Test Safari 10 instead of 8/9

### DIFF
--- a/wct.conf.json
+++ b/wct.conf.json
@@ -11,13 +11,8 @@
 
         {
           "browserName":  "safari",
-          "platform":     "OS X 10.11",
-          "version":      "9"
-        },
-        {
-          "browserName":  "safari",
-          "platform":     "OS X 10.10",
-          "version":      "8"
+          "platform":     "OS X 10.12",
+          "version":      "10"
         },
 
         {


### PR DESCRIPTION
Now Sauce Labs tests are failing :\

Our Safari 8/9 usage represents 0.2% of sessions.