### PR TITLE
Fix demo dialog fullscreen behavior

### DIFF
--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -621,7 +621,7 @@
         if (!(this.versionRoute || this.data))
           return;
 
-        if (window.matchMedia('max-width: 500px').matches) {
+        if (window.matchMedia('(max-width: 500px)').matches) {
           this._hideMainContent = true;
           this.fire('fullscreen-start');
         }


### PR DESCRIPTION
TIL `matchMedia()` requires parentheses in the expression.

Not sure how to add a test for this since we don't do any mobile emulation tests.