### PR TITLE
Don't try and scan a package & handle fatal errors

### DIFF
--- a/analysis/src/analyzer.js
+++ b/analysis/src/analyzer.js
@@ -32,7 +32,6 @@ class AnalyzerRunner {
         Promise.all(inputs.map((i) => analyzer.analyze(i))).then(function(documents) {
           resolve(generateAnalysis(documents, ''));
         }).catch(function(error) {
-          debugger;
           Ana.fail('analyzer/analyze', inputs, error);
           var fatal = error.code && fatalErrorCodes.indexOf(error.code) != -1;
           reject({retry: !fatal, error: error});

--- a/analysis/src/analyzer.js
+++ b/analysis/src/analyzer.js
@@ -11,7 +11,7 @@ const PackageUrlResolver = require('polymer-analyzer/lib/url-loader/package-url-
 
 class AnalyzerRunner {
   analyze(inputs) {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       Ana.log('analyzer/analyze', inputs);
 
       const analyzer = new Analyzer({
@@ -28,12 +28,14 @@ class AnalyzerRunner {
           resolve(generateAnalysis(_package, ''));
         }).catch(function() {
           Ana.fail('analyzer/analyze', inputs, isNotTest);
+          reject({retry: true, error: error});
         });
       } else {
         Promise.all(inputs.map((i) => analyzer.analyze(i))).then(function(documents) {
           resolve(generateAnalysis(documents, ''));
-        }).catch(function() {
+        }).catch(function(error) {
           Ana.fail('analyzer/analyze', inputs);
+          reject({retry: true, error: error});
         });
       }
 

--- a/analysis/src/analyzer.js
+++ b/analysis/src/analyzer.js
@@ -9,6 +9,9 @@ const Feature = require('polymer-analyzer/lib/model/model');
 const FSUrlLoader = require('polymer-analyzer/lib/url-loader/fs-url-loader').FSUrlLoader;
 const PackageUrlResolver = require('polymer-analyzer/lib/url-loader/package-url-resolver').PackageUrlResolver;
 
+// Don't retry ENOENT ('No such file or directory').
+const fatalErrorCodes = ['ENOENT'];
+
 class AnalyzerRunner {
   analyze(inputs) {
     return new Promise((resolve, reject) => {
@@ -24,18 +27,15 @@ class AnalyzerRunner {
           feature.sourceRange != null && !isInTests.test(feature.sourceRange.file);
 
       if (inputs == null || inputs.length === 0) {
-        analyzer.analyzePackage().then(function(_package) {
-          resolve(generateAnalysis(_package, ''));
-        }).catch(function() {
-          Ana.fail('analyzer/analyze', inputs, isNotTest);
-          reject({retry: true, error: error});
-        });
+        resolve({});
       } else {
         Promise.all(inputs.map((i) => analyzer.analyze(i))).then(function(documents) {
           resolve(generateAnalysis(documents, ''));
         }).catch(function(error) {
-          Ana.fail('analyzer/analyze', inputs);
-          reject({retry: true, error: error});
+          debugger;
+          Ana.fail('analyzer/analyze', inputs, error);
+          var fatal = error.code && fatalErrorCodes.indexOf(error.code) != -1;
+          reject({retry: !fatal, error: error});
         });
       }
 

--- a/analysis/test/analyzer-test.js
+++ b/analysis/test/analyzer-test.js
@@ -23,4 +23,12 @@ describe('AnalyzerRunner', function() {
       expect(result.elements[0]).to.have.property('classname', 'ShopImage');
     });
   });
+
+  it('ignores unknown files', function(done) {
+    var analyzer = new AnalyzerRunner();
+    analyzer.analyze([path.resolve(__dirname, 'resources/does-not-exist.not-found')]).catch(function() {
+      // Successfully rejected promise.
+      done();
+    });
+  });
 });


### PR DESCRIPTION
This fixes #897 as currently it fails to reject the promise when there's an exception. This results in the instance being locked up for 2 minutes and prevents other tasks from being processed.

 * Don't try analyze a package, since we currently don't have the root of the directory. We can probably change this to work in the future.
 * Treat file not found as a fatal error, since this will never recover properly, unless we choose to ignore them in the future. Given this would be 'unintended', maybe failure is better, although it is opaque right now.