### PR TITLE
Add support for bower demos

### DIFF
--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -328,6 +328,10 @@
           <div class="sidebar-nav box loader" role="navigation" collapse$="[[_shouldCollapseNav(bundledElements)]]" loading$="[[!docs]]">
             <a href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]">Overview</a>
 
+            <template is="dom-repeat" items="[[_bowerDemos]]" as="demo">
+              <a class="demo-link sub-item" rel="nofollow" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/demo/[[demo.path]]" on-click="_demoClicked"><span>[[demo.title]]</span></a>
+            </template>
+
             <template is="dom-repeat" items="[[dupedDemos]]" as="demo">
               <a class="demo-link sub-item" rel="nofollow" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/demo/[[demo.path]]" on-click="_demoClicked"><span>[[demo.desc]]</span></a>
             </template>
@@ -538,6 +542,7 @@
         this.dupedDemos = [];
         this.collections = null;
         this.docs = null;
+        this._bowerDemos = [];
       },
 
       _splitRoute: function() {
@@ -693,6 +698,13 @@
         this.fire('document-title', this.data.owner + '/' + this.data.repo);
         if (this.demo)
           this._showDemo();
+
+        var demos = [];
+        var bowerDemosNames = Object.keys(this.data.bower.demos || {});
+        for (var i = 0; i < bowerDemosNames.length; i++) {
+          demos.push({title: bowerDemosNames[i], path: this.data.bower.demos[bowerDemosNames[i]]});
+        }
+        this.set('_bowerDemos', demos);
       },
 
       _metaError: function(event, error) {
@@ -774,6 +786,11 @@
         var paths = Object.keys(demoCounts);
         if (paths.length == 1)
           demoCounts[paths[0]] = 2;
+
+        // Bower demos are already shown, mark them as dupes.
+        this._bowerDemos.forEach(function(demo) {
+          demoCounts[demo.path] = -1;
+        });
 
         this.bundledElements.forEach(dedupeDemos);
         this.bundledBehaviors.forEach(dedupeDemos);

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -751,13 +751,13 @@
         this.bundledElements = this._elements();
         this.bundledBehaviors = this._behaviors();
         if (!this.dupedDemos || !this.dupedDemos.length)
-          this.dupedDemos = this._demos();
+          this.dupedDemos = this._dedupeDemos(this._bowerDemos, this.bundledElements, this.bundledBehaviors);
         this._hasRepoContents = this.bundledElements.length || this.bundledBehaviors.length || this.dupedDemos.length;
         var content = this.docs.analysis || this.docs.content;
         this.descriptor = content.elementsByTagName[this.subElement] || content.behaviorsByName[this.subElement];
       },
 
-      _demos: function() {
+      _dedupeDemos: function(bowerDemos, elements, behaviors) {
         var demoCounts = {};
         var dupedDemos = [];
 
@@ -768,19 +768,22 @@
         }
 
         function dedupeDemos(element) {
-          for (var j = 0; j < element.demos.length; j++) {
+          var j = 0;
+          while (j < element.demos.length) {
             var demo = element.demos[j];
             if (demoCounts[demo.path] > 1) {
               dupedDemos.push(element.demos.splice(j, 1)[0]);
               demoCounts[demo.path] = -1;
             } else if (demoCounts[demo.path] == -1) {
               element.demos.splice(j, 1);
+            } else {
+              j++;
             }
           }
         }
 
-        this.bundledElements.forEach(countDemos);
-        this.bundledBehaviors.forEach(countDemos);
+        elements.forEach(countDemos);
+        behaviors.forEach(countDemos);
 
         // Show single demos at the top by marking them as a dupe.
         var paths = Object.keys(demoCounts);
@@ -788,12 +791,12 @@
           demoCounts[paths[0]] = 2;
 
         // Bower demos are already shown, mark them as dupes.
-        this._bowerDemos.forEach(function(demo) {
+        bowerDemos.forEach(function(demo) {
           demoCounts[demo.path] = -1;
         });
 
-        this.bundledElements.forEach(dedupeDemos);
-        this.bundledBehaviors.forEach(dedupeDemos);
+        elements.forEach(dedupeDemos);
+        behaviors.forEach(dedupeDemos);
         return dupedDemos;
       },
 

--- a/client/src/custom-element-demo.html
+++ b/client/src/custom-element-demo.html
@@ -253,10 +253,10 @@
       _initExample: function(example, data) {
         if (!example || !data)
           return;
-        var endScript = '/script>';
+        var endScript = 'script>';
         var source = [
           '<!-- START-HIDDEN-SECTION: Add imports and styling here. -->',
-          '<script src="../webcomponentsjs/webcomponents-lite.js"><' + endScript,
+          '<script src="../webcomponentsjs/webcomponents-lite.js"><' + '/'.toString() + endScript,
           '<link rel="import" href="' + data.repo + '.html">',
           '<!-- END-HIDDEN-SECTION: Add the visible part of the demo below. -->',
           '<' + data.repo + '>...</' + data.repo + '>',

--- a/client/test/catalog-element.html
+++ b/client/test/catalog-element.html
@@ -126,5 +126,35 @@
       });
     });
 
+    test('dedupeDemos()', function() {
+      elementPage = fixture('element-page');
+
+      function gen() {
+        var result = [];
+        for (var i = 0; i < arguments.length; i++)
+          result.push({path: arguments[i] + '.html'})
+        return result;
+      }
+
+      function genElement() {
+        return [{demos: gen.apply(null, arguments)}];
+      }
+
+      expect(elementPage._dedupeDemos([], [], [])).to.be.empty;
+      expect(elementPage._dedupeDemos(gen('a'), genElement('b'), genElement('c'))).to.be.empty;
+
+      var elements = genElement('b', 'c');
+      var behaviors = genElement('b');
+      expect(elementPage._dedupeDemos(gen('a'), elements, behaviors)).to.eql(gen('b'));
+      expect(elements).to.eql(genElement('c'));
+      expect(behaviors).to.eql(genElement());
+
+      elements = genElement('element', 'shared');
+      behaviors = genElement('bowera', 'shared', 'behavior');
+      expect(elementPage._dedupeDemos(gen('bowera', 'bowerb'), elements, behaviors)).to.eql(gen('shared'));
+      expect(elements).to.eql(genElement('element'));
+      expect(behaviors).to.eql(genElement('behavior'));
+    });
+
   });
 </script>

--- a/src/api.py
+++ b/src/api.py
@@ -195,12 +195,13 @@ class LibraryMetadata(object):
     bower = yield bower_future
     if bower is not None:
       bower_json = json.loads(bower.content)
-      dependencies = bower_json.get('dependencies', [])
+      dependencies = bower_json.get('dependencies', {})
       result['dependency_count'] = len(dependencies)
       result['bower'] = {
           'license': bower_json.get('license', ''),
           'dependencies': dependencies,
           'keywords': bower_json.get('keywords', []),
+          'demos': bower_json.get('demos', {}),
       }
       if result.get('description', '') == '':
         result['description'] = bower_json.get('description', '')


### PR DESCRIPTION
Supports demos specified just in `bower.json`. This is an object with titles and paths as key/value pairs respectively. Closes #899.

```
...
"demos": {
    "My Simple Demo": "path/demo.html"
}
...
```

This patch modifies the API to return this specified list and updates the client to dedupe these from any demos that hydrolysis/analyzer might return and display them.