### PR TITLE
Implement support for custom pages

### DIFF
--- a/API.md
+++ b/API.md
@@ -28,6 +28,12 @@ Optionally, you can specify a specific version:
 GET /api/docs/:owner/:repo/:version
 ```
 
+## Get custom page for a component
+In cases where a component specificies custom markdown files, the corresponding HTML is served via this API. Note version is not optional. The paths can be discovered from the `meta` response.
+```
+GET /api/page/:owner/:repo/:version/:path
+```
+
 ## Get collection dependencies
 ```
 GET /api/dependencies/:owner/:repo

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -435,7 +435,7 @@
             <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!docs]]" readme="[[data.readme]]" base-urls="[[baseUrls]]" hidden="[[_or(subElement, pagePath)]]"></catalog-element-readme>
           </template>
           <template is="dom-if" if="[[pagePath]]">
-            <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!docs]]" readme="[[_customPage]]" base-urls="[[baseUrls]]" hidden="[[!_or(subElement, pagePath)]]"></catalog-element-readme>
+            <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!docs]]" readme="[[_customPage]]" base-urls="[[baseUrls]]"></catalog-element-readme>
           </template>
 
           <div hidden="[[!subElement]]">
@@ -730,7 +730,7 @@
 
         this.set('_bowerDemos', objectToArray(this.data.bower.demos));
         this.set('_customPages', objectToArray(this.data.bower.pages));
-        // Can only trigger to ensure version is known & specified.
+        // Can only triggered after meta to ensure version is known & specified.
         if (this.pagePath)
           this.$.pageAjax.generateRequest();
       },

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -155,7 +155,7 @@
         text-transform: capitalize;
       }
 
-      .sidebar-nav a.demo-link:after, .sidebar-nav a.api-link:after {
+      .sidebar-nav a.demo-link:after, .sidebar-nav a.api-link:after, .sidebar-nav a.page-link:after {
         content: 'demo';
         text-transform: uppercase;
         font-weight: normal;
@@ -166,6 +166,10 @@
 
       .sidebar-nav a.api-link:after {
         content: 'api';
+      }
+
+      .sidebar-nav a.page-link:after {
+        content: 'doc';
       }
 
       collection-card {
@@ -308,6 +312,12 @@
       handle-as="json"
       last-response="{{collections}}"></iron-ajax>
 
+    <iron-ajax
+      id="pageAjax"
+      url="[[baseUrls.api]]/api/page/[[owner]]/[[repo]]/[[data.version]]/[[pagePath]]"
+      handle-as="text"
+      last-response="{{_customPage}}"></iron-ajax>
+
     <lazy-block id="block"></lazy-block>
 
     <div id="container" hidden$="[[_hideMainContent]]">
@@ -334,6 +344,10 @@
 
             <template is="dom-repeat" items="[[dupedDemos]]" as="demo">
               <a class="demo-link sub-item" rel="nofollow" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/demo/[[demo.path]]" on-click="_demoClicked"><span>[[demo.desc]]</span></a>
+            </template>
+
+            <template is="dom-repeat" items="[[_customPages]]" as="page">
+              <a class="page-link" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/page/[[page.path]]"><span>[[page.title]]</span></a>
             </template>
 
             <template is="dom-repeat" items="[[bundledElements]]" as="element">
@@ -416,9 +430,12 @@
           </div>
           <h2 class="page-subtitle desktop-only">[[data.description]] <a title="Home page link" href="[[data.homepage]]" hidden$="[[_redundantLink(data.homepage)]]">[[data.homepage]]</a></h2>
 
-          <h1 hidden="[[subElement]]">README.md</h1>
+          <h1 hidden="[[subElement]]">[[_pageTitle(_customPages, pagePath)]]</h1>
           <template is="dom-if" if="[[data]]">
-            <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!docs]]" readme="[[data.readme]]" base-urls="[[baseUrls]]" hidden="[[subElement]]"></catalog-element-readme>
+            <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!docs]]" readme="[[data.readme]]" base-urls="[[baseUrls]]" hidden="[[_or(subElement, pagePath)]]"></catalog-element-readme>
+          </template>
+          <template is="dom-if" if="[[pagePath]]">
+            <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!docs]]" readme="[[_customPage]]" base-urls="[[baseUrls]]" hidden="[[!_or(subElement, pagePath)]]"></catalog-element-readme>
           </template>
 
           <div hidden="[[!subElement]]">
@@ -543,12 +560,14 @@
         this.collections = null;
         this.docs = null;
         this._bowerDemos = [];
+        this._customPages = [];
       },
 
       _splitRoute: function() {
         this.versionRoute = '';
         this.subElement = null;
         this.demo = null;
+        this.pagePath = null;
 
         var split = this.route.path.split('/');
         // Bug in app-route doesn't always have a leading /
@@ -567,6 +586,10 @@
           if (split[split.length - 1] == '')
             split[split.length - 1] = 'index.html';
           this.demo = split.join('/');
+          split = [];
+        } else if (split.length && split[0] == 'page') {
+          split.shift();
+          this.pagePath = split.join('/');
           split = [];
         }
 
@@ -682,6 +705,12 @@
       },
 
       _metaResponse: function() {
+        function objectToArray(object) {
+          return Object.keys(object || {}).map(function(title) {
+            return {title: title, path: object[title]};
+          });
+        }
+
         if (this.data.status == 'pending') {
           this.async(this.$.metaAjax.generateRequest.bind(this.$.metaAjax), 500);
           return;
@@ -699,12 +728,22 @@
         if (this.demo)
           this._showDemo();
 
-        var demos = [];
-        var bowerDemosNames = Object.keys(this.data.bower.demos || {});
-        for (var i = 0; i < bowerDemosNames.length; i++) {
-          demos.push({title: bowerDemosNames[i], path: this.data.bower.demos[bowerDemosNames[i]]});
+        this.set('_bowerDemos', objectToArray(this.data.bower.demos));
+        this.set('_customPages', objectToArray(this.data.bower.pages));
+        // Can only trigger to ensure version is known & specified.
+        if (this.pagePath)
+          this.$.pageAjax.generateRequest();
+      },
+
+      _pageTitle: function(pages, pagePath) {
+        if (!pagePath)
+          return 'README.md';
+        for (var i = 0; i < pages.length; i++) {
+          if (pages[i].path == pagePath) {
+            return pages[i].title;
+          }
         }
-        this.set('_bowerDemos', demos);
+        return pagePath;
       },
 
       _metaError: function(event, error) {

--- a/src/api.py
+++ b/src/api.py
@@ -202,6 +202,7 @@ class LibraryMetadata(object):
           'dependencies': dependencies,
           'keywords': bower_json.get('keywords', []),
           'demos': bower_json.get('demos', {}),
+          'pages': bower_json.get('pages', {}),
       }
       if result.get('description', '') == '':
         result['description'] = bower_json.get('description', '')

--- a/src/api.py
+++ b/src/api.py
@@ -366,6 +366,28 @@ class GetDocs(webapp2.RequestHandler):
     self.response.headers['Content-Type'] = 'application/json'
     self.response.write(json.dumps(result))
 
+
+class GetPage(webapp2.RequestHandler):
+  @ndb.toplevel
+  def get(self, owner, repo, ver, path):
+    self.response.headers['Access-Control-Allow-Origin'] = '*'
+
+    version_key = ndb.Key(Library, Library.id(owner, repo), Version, ver)
+
+    if version_key is None:
+      self.response.set_status(404)
+      self.response.write('Invalid repo/version')
+      return
+
+    page = Content.get_by_id('page-' + path, parent=version_key, read_policy=ndb.EVENTUAL_CONSISTENCY)
+
+    if page is None:
+      self.response.set_status(404)
+      self.response.write('Cannot find page %s' % path);
+      return
+
+    self.response.write(page.content)
+
 class GetAuthor(webapp2.RequestHandler):
   @ndb.toplevel
   def get(self, author):
@@ -643,6 +665,7 @@ app = webapp2.WSGIApplication([
     webapp2.Route(r'/api/meta/<owner>/<repo>/<ver>', handler=GetMetadata),
     webapp2.Route(r'/api/docs/<owner>/<repo>', handler=GetDocs),
     webapp2.Route(r'/api/docs/<owner>/<repo>/<ver>', handler=GetDocs),
+    webapp2.Route(r'/api/page/<owner>/<repo>/<ver>/<path:.*>', handler=GetPage),
     webapp2.Route(r'/api/dependencies/<owner>/<repo>', handler=GetDependencies),
     webapp2.Route(r'/api/dependencies/<owner>/<repo>/<version>', handler=GetDependencies),
     webapp2.Route(r'/api/collections/<owner>/<repo>', handler=GetCollections),

--- a/src/api.py
+++ b/src/api.py
@@ -383,7 +383,7 @@ class GetPage(webapp2.RequestHandler):
 
     if page is None:
       self.response.set_status(404)
-      self.response.write('Cannot find page %s' % path);
+      self.response.write('Cannot find page %s' % path)
       return
 
     self.response.write(page.content)

--- a/src/manage.py
+++ b/src/manage.py
@@ -693,15 +693,14 @@ class IngestVersion(RequestHandler):
 
     bower_json = json.loads(bower.content)
 
-    for title, path in bower_json.get('pages', {}).iteritems():
-      id = 'page-' + path
+    for _, path in bower_json.get('pages', {}).iteritems():
       response = util.github_get('repos', self.owner, self.repo, 'contents/' + path, params={'ref': self.sha})
 
       if response.status_code == 200:
         response_json = json.loads(response.content)
         markdown = None
         # Ensure a file was returned
-        if type(response_json) is dict and response_json.get('type') == 'file':
+        if isinstance(response_json, dict) and response_json.get('type') == 'file':
           markdown = base64.b64decode(response_json.get('content'))
       elif response.status_code == 404:
         markdown = None

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -641,7 +641,7 @@ class IngestLibraryTest(ManageTestBase):
     self.respond_to_github(r'https://api.github.com/repos/org/repo/readme\?ref=sha', '{"content":"%s"}' % b64encode('README'))
     self.respond_to('https://raw.githubusercontent.com/org/repo/sha/bower.json', '{"pages":{"custom doc":"doc.md"}}')
     self.respond_to_github('https://api.github.com/markdown', '<html>README</html>')
-    self.respond_to_github(r'https://api.github.com/repos/org/repo/contents\?path=doc\.md&ref=sha', '{"content":"%s"}' % b64encode('doc.md'))
+    self.respond_to_github(r'https://api.github.com/repos/org/repo/contents/doc.md\?ref=sha', '{"content":"%s", "type":"file"}' % b64encode('doc.md'))
     self.respond_to_github('https://api.github.com/markdown', '<html>doc.md</html>')
 
     response = self.app.get(util.ingest_version_task('org', 'repo', 'v1.0.0'), headers={'X-AppEngine-QueueName': 'default'})

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -647,7 +647,6 @@ class IngestLibraryTest(ManageTestBase):
     response = self.app.get(util.ingest_version_task('org', 'repo', 'v1.0.0'), headers={'X-AppEngine-QueueName': 'default'})
     self.assertEqual(response.status_int, 200)
 
-    version = Version.get_by_id('v1.0.0', parent=library_key)
     page = ndb.Key(Library, 'org/repo', Version, 'v1.0.0', Content, 'page-doc.md').get()
     self.assertEqual(page.content, '<html>doc.md</html>')
 

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -634,6 +634,23 @@ class IngestLibraryTest(ManageTestBase):
     self.assertIsNotNone(library.error)
     self.assertEqual(library.status, Status.error)
 
+  def test_ingest_version_pages(self):
+    library_key = Library(id='org/repo', metadata='{"full_name": "NSS Bob", "stargazers_count": 420, "subscribers_count": 419, "forks": 418, "updated_at": "2011-8-10T13:47:12Z"}').put()
+    Version(id='v1.0.0', parent=library_key, sha='sha').put()
+
+    self.respond_to_github(r'https://api.github.com/repos/org/repo/readme\?ref=sha', '{"content":"%s"}' % b64encode('README'))
+    self.respond_to('https://raw.githubusercontent.com/org/repo/sha/bower.json', '{"pages":{"custom doc":"doc.md"}}')
+    self.respond_to_github('https://api.github.com/markdown', '<html>README</html>')
+    self.respond_to_github(r'https://api.github.com/repos/org/repo/contents\?path=doc\.md&ref=sha', '{"content":"%s"}' % b64encode('doc.md'))
+    self.respond_to_github('https://api.github.com/markdown', '<html>doc.md</html>')
+
+    response = self.app.get(util.ingest_version_task('org', 'repo', 'v1.0.0'), headers={'X-AppEngine-QueueName': 'default'})
+    self.assertEqual(response.status_int, 200)
+
+    version = Version.get_by_id('v1.0.0', parent=library_key)
+    page = ndb.Key(Library, 'org/repo', Version, 'v1.0.0', Content, 'page-doc.md').get()
+    self.assertEqual(page.content, '<html>doc.md</html>')
+
 class UpdateIndexesTest(ManageTestBase):
   def test_update_indexes(self):
     metadata = """{

--- a/tests.py
+++ b/tests.py
@@ -36,7 +36,8 @@ def main(sdk_path):
 
   test_path = os.path.dirname(sys.modules[__name__].__file__)
 
-  logging.disable(logging.CRITICAL)
+  logging.getLogger().setLevel(20)
+  # logging.disable(logging.CRITICAL)
 
   from colour_runner import runner
 

--- a/tests.py
+++ b/tests.py
@@ -36,8 +36,7 @@ def main(sdk_path):
 
   test_path = os.path.dirname(sys.modules[__name__].__file__)
 
-  logging.getLogger().setLevel(20)
-  # logging.disable(logging.CRITICAL)
+  logging.disable(logging.CRITICAL)
 
   from colour_runner import runner
 


### PR DESCRIPTION
This enables support for custom pages specified in `bower.json`. For example:
```
...
"pages": {
  "My doc title": "path/to/markdown.md"
}
...
```

This markdown file is processed in the same way as README.md, which means:
 * Rendered by GitHub
 * Supports inline demos since same inline demo transformation occurs.

These processed files are exposed in a new `page` API.

Closes #904.