### PR TITLE
Support fully qualified URLs in collection bower.json

### DIFF
--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -1,5 +1,6 @@
 from google.appengine.ext import ndb
 
+import re
 import versiontag
 
 class CollectionReference(ndb.Model):
@@ -167,6 +168,8 @@ class Dependency(object):
 
   @staticmethod
   def from_string(dep_string):
+    # Strip fully qualified URLs.
+    dep_string = re.sub(r'https://github\.com/(.*)\.git', r'\1', dep_string)
     bits = dep_string.split('#', 1)
     if len(bits) == 1:
       bits.append('*')

--- a/src/datamodel_test.py
+++ b/src/datamodel_test.py
@@ -1,4 +1,4 @@
-from datamodel import Library, Version, Status, VersionCache, CollectionReference
+from datamodel import Library, Version, Status, VersionCache, CollectionReference, Dependency
 
 from google.appengine.ext import ndb
 
@@ -78,3 +78,15 @@ class CollectionReferenceTests(TestBase):
     self.assertEqual(collection_keys, [
         collection_v2,
     ])
+
+class DependencyTests(TestBase):
+  def test_from_string(self):
+    dependency = Dependency.from_string('owner/repo')
+    self.assertEqual(dependency.owner, 'owner')
+    self.assertEqual(dependency.repo, 'repo')
+    self.assertEqual(dependency.version, '*')
+
+    dependency = Dependency.from_string('https://github.com/owner/repo.git#master')
+    self.assertEqual(dependency.owner, 'owner')
+    self.assertEqual(dependency.repo, 'repo')
+    self.assertEqual(dependency.version, 'master')


### PR DESCRIPTION
See https://github.com/cordova-elements/cordova-elements/blob/master/bower.json for example

Causing task queue failure for `task/ensure`.