### PR TITLE
Dynamically add open graph meta tags

### DIFF
--- a/client/bot-filter.py
+++ b/client/bot-filter.py
@@ -12,7 +12,7 @@ class FilterUserAgent(webapp2.RequestHandler):
     if filter:
       try:
         # Set deadline for fetch to 10 seconds
-        urlfetch.set_default_fetch_deadline(20)
+        urlfetch.set_default_fetch_deadline(10)
         result = urlfetch.fetch('https://bot-render.appspot.com/?url=%s' % self.request.url)
         if result.status_code == 200:
           self.response.write(result.content)
@@ -20,8 +20,7 @@ class FilterUserAgent(webapp2.RequestHandler):
           self.response.status_code = result.status_code
         return
       except urlfetch.Error:
-          logging.exception('Caught exception fetching url')
-
+        logging.exception('Caught exception fetching url')
 
     file = open('index.html', 'r')
     self.response.out.write(file.read())

--- a/client/bot-filter.py
+++ b/client/bot-filter.py
@@ -1,0 +1,40 @@
+from google.appengine.api import urlfetch
+
+import logging
+import webapp2
+import re
+
+class FilterUserAgent(webapp2.RequestHandler):
+  def get(self, path):
+    filtered = ['Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)']
+    agent = str(self.request.headers['User-Agent'])
+    filter = False
+    for filter in filtered:
+      if agent.find(filter) is not -1:
+        filter = True
+
+    ## TODO
+    filter = True
+    if filter:
+      try:
+        # Set deadline for fetch to 10 seconds
+        urlfetch.set_default_fetch_deadline(20)
+        url = 'https://dynamic-meta.appspot.com'
+        result = urlfetch.fetch('https://bot-render.appspot.com/?url=%s' % url)
+        if result.status_code == 200:
+          self.response.write(result.content)
+        else:
+          self.response.status_code = result.status_code
+        return
+      except urlfetch.Error:
+          logging.exception('Caught exception fetching url')
+
+
+    file = open('index.html', 'r')
+    self.response.out.write(file.read())
+    file.close()
+
+# pylint: disable=invalid-name
+app = webapp2.WSGIApplication([
+    webapp2.Route(r'/<:.*>', handler=FilterUserAgent),
+], debug=True)

--- a/client/bot-filter.py
+++ b/client/bot-filter.py
@@ -6,21 +6,14 @@ import re
 
 class FilterUserAgent(webapp2.RequestHandler):
   def get(self, path):
-    filtered = ['Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)']
-    agent = str(self.request.headers['User-Agent'])
-    filter = False
-    for filter in filtered:
-      if agent.find(filter) is not -1:
-        filter = True
+    filtered = r'baiduspider|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator';
+    filter = re.search(filtered, str(self.request.headers['User-Agent']))
 
-    ## TODO
-    filter = True
     if filter:
       try:
         # Set deadline for fetch to 10 seconds
         urlfetch.set_default_fetch_deadline(20)
-        url = 'https://dynamic-meta.appspot.com'
-        result = urlfetch.fetch('https://bot-render.appspot.com/?url=%s' % url)
+        result = urlfetch.fetch('https://bot-render.appspot.com/?url=%s' % self.request.url)
         if result.status_code == 200:
           self.response.write(result.content)
         else:
@@ -37,4 +30,4 @@ class FilterUserAgent(webapp2.RequestHandler):
 # pylint: disable=invalid-name
 app = webapp2.WSGIApplication([
     webapp2.Route(r'/<:.*>', handler=FilterUserAgent),
-], debug=True)
+], debug=False)

--- a/client/client.yaml
+++ b/client/client.yaml
@@ -50,14 +50,20 @@ handlers:
   upload: index.html
   static_files: index.html
   secure: always
+  application_readable: true
+- url: /elements?(/.*)?
+  script: bot-filter.app
+  secure: always
 - url: /(about|introduction|community|assets|polyfills|resources|libraries|specs|launch-announcement)(/.*)?
   upload: index.html
   static_files: index.html
   secure: always
-- url: /(author|collections?|elements?|search|preview|preview-integration|publish|publish-collection)(/.*)?
+  application_readable: true
+- url: /(author|collections?|search|preview|preview-integration|publish|publish-collection)(/.*)?
   upload: index.html
   static_files: index.html
   secure: always
+  application_readable: true
   # Legacy pathing redirects
 - url: /(articles|podcasts|presentations)(.*)
   script: client.app

--- a/client/index.html
+++ b/client/index.html
@@ -16,11 +16,6 @@
     <meta name="theme-color" content="#ffffff">
 
     <meta property="og:image" content="https://www.webcomponents.org/assets/logo-192x192.png">
-    <meta property="og:image:secure_url" content="https://www.webcomponents.org/assets/logo-192x192.png">
-    <meta property="og:image:type" content="image/png">
-    <meta property="og:image:width" content="192">
-    <meta property="og:image:height" content="192">
-
     <link type="application/opensearchdescription+xml" rel="search" href="/opensearch.xml">
 
     <style>

--- a/client/polymer.json
+++ b/client/polymer.json
@@ -26,6 +26,7 @@
     "third_party/octicons/sprite.octicons.svg",
     "client.yaml",
     "client.py",
-    "robots.txt"
+    "robots.txt",
+    "bot-filter.py"
   ]
 }

--- a/client/src/catalog-app.html
+++ b/client/src/catalog-app.html
@@ -578,12 +578,15 @@
         'document-title': '_changeTitle',
         'fullscreen-start': '_fullscreenStart',
         'fullscreen-end': '_fullscreenEnd',
+        'meta-set': '_onMetaSet',
       },
 
       created: function() {
         if (window.performance && performance.mark)
           performance.mark('catalog-app.created');
         this.removeAttribute('unresolved');
+        this.fire('meta-set', {property: 'og:site-name', content: 'webcomponents.org'});
+        this.fire('meta-set', {property: 'og:determiner', content: ''});
       },
 
       _notifyUser: function(event) {
@@ -811,6 +814,16 @@
 
       _fullscreenEnd: function() {
         this.removeAttribute('fullscreen');
+      },
+
+      _onMetaSet: function(event) {
+        var element = document.head.querySelector('meta[property="' + event.detail.property + '"]');
+        if (!element) {
+          element = document.createElement('meta');
+          element.setAttribute('property', event.detail.property);
+          document.head.appendChild(element);
+        }
+        element.setAttribute('content', event.detail.content);
       },
 
     });

--- a/client/src/catalog-element-readme.html
+++ b/client/src/catalog-element-readme.html
@@ -254,6 +254,21 @@
           links[i].setAttribute('src', links[i].getAttribute('src').replace(relativeRegex, githubBase + '/raw/' + defaultBranch + '/$1'));
       },
 
+      attached: function() {
+        if (this.data && this.readme)
+          this._setMetaImage();
+      },
+
+      _setMetaImage: function() {
+        var images = Polymer.dom(this.$.contents).querySelectorAll('img');
+        for (var i = 0; i < images.length; i++) {
+          if (images[i].src.match(/(png|jpg|jpeg)/)) {
+            this.fire('meta-set', {property: 'og:image', content: images[i].src});
+            return;
+          }
+        }
+      },
+
       _loadDemos: function(docsPending) {
         if (docsPending)
           return;

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -733,6 +733,12 @@
         // Can only triggered after meta to ensure version is known & specified.
         if (this.pagePath)
           this.$.pageAjax.generateRequest();
+
+        this.fire('meta-set', {property: 'og:title', content: this.data.owner + '/' + this.data.repo + ' (' + this.data.version + ')'});
+        this.fire('meta-set', {property: 'og:type', content: 'website'});
+        this.fire('meta-set', {property: 'og:description', content: this.data.description});
+        this.fire('meta-set', {property: 'og:url', content: document.location.href});
+        this.fire('meta-set', {property: 'og:image', content: this.data.avatar_url});
       },
 
       _pageTitle: function(pages, pagePath) {


### PR DESCRIPTION
Partly addresses #381 

This filters requests from static bot user agents which don't render webpages to the bot-render service, allowing for dynamically generated meta tags.

The tags are added just for `/element/*` pages. Image will use first image in readme file, falling back to the author's avatar.