### PR TITLE
Fix cascading load of docs then demos

### DIFF
--- a/client/src/catalog-element-readme.html
+++ b/client/src/catalog-element-readme.html
@@ -165,7 +165,10 @@
       properties: {
         data: Object,
 
-        docsPending: Boolean,
+        docsPending: {
+          type: Boolean,
+          value: true,
+        },
 
         readme: String,
 

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -432,10 +432,10 @@
 
           <h1 hidden="[[subElement]]">[[_pageTitle(_customPages, pagePath)]]</h1>
           <template is="dom-if" if="[[data]]">
-            <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!docs]]" readme="[[data.readme]]" base-urls="[[baseUrls]]" hidden="[[_or(subElement, pagePath)]]"></catalog-element-readme>
+            <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!_dependenciesReady(docs)]]" readme="[[data.readme]]" base-urls="[[baseUrls]]" hidden="[[_or(subElement, pagePath)]]"></catalog-element-readme>
           </template>
           <template is="dom-if" if="[[pagePath]]">
-            <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!docs]]" readme="[[_customPage]]" base-urls="[[baseUrls]]"></catalog-element-readme>
+            <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!_dependenciesReady(docs)]]" readme="[[_customPage]]" base-urls="[[baseUrls]]"></catalog-element-readme>
           </template>
 
           <div hidden="[[!subElement]]">
@@ -768,6 +768,10 @@
           return;
         this.$.block.unblock();
         this._lazyUnblocked = true;
+      },
+
+      _dependenciesReady: function(docs) {
+        return docs && docs.status == 'ready';
       },
 
       _docsResponse: function() {

--- a/client/test/catalog-element-readme.html
+++ b/client/test/catalog-element-readme.html
@@ -5,6 +5,8 @@
 
 <!-- Import the element to test -->
 <link rel="import" href="../src/catalog-element-readme.html">
+<!-- Normally lazy loaded -->
+<link rel="import" href="../src/custom-element-demo.html">
 
 <test-fixture id="basic">
   <template>
@@ -15,17 +17,32 @@
 <script>
   suite('catalog-element-readme inline demo test', function() {
     var readmeElement;
+
     setup(function() {
       readmeElement = fixture('basic');
       readmeElement.data = {owner: 'owner', repo: 'repo', version: 'version'};
       readmeElement.baseUrls = {userContent:''};
-    });
-    test('Should create custom-element-demo', function() {
       readmeElement.readme = '<div class="highlight highlight-text-html-basic"><pre>&lt;<span class="pl-ent">custom</span><span class="pl-e">-element-demo</span> <span class="pl-e">width</span>=<span class="pl-s"><span class="pl-pds">"</span>500<span class="pl-pds">"</span></span> <span class="pl-e">height</span>=<span class="pl-s"><span class="pl-pds">"</span>500<span class="pl-pds">"</span></span>&gt; &lt;<span class="pl-ent">template</span>&gt; <span class="pl-s1"> &lt;<span class="pl-ent">script</span> <span class="pl-e">src</span>=<span class="pl-s"><span class="pl-pds">"</span>../../webcomponentsjs/webcomponents-lite.js<span class="pl-pds">"</span></span>&gt;&lt;/<span class="pl-ent">script</span>&gt;</span> &lt;<span class="pl-ent">link</span> <span class="pl-e">rel</span>=<span class="pl-s"><span class="pl-pds">"</span>import<span class="pl-pds">"</span></span> <span class="pl-e">href</span>=<span class="pl-s"><span class="pl-pds">"</span>../../iron-demo-helpers/demo-snippet.html<span class="pl-pds">"</span></span>&gt; &lt;<span class="pl-ent">link</span> <span class="pl-e">rel</span>=<span class="pl-s"><span class="pl-pds">"</span>import<span class="pl-pds">"</span></span> <span class="pl-e">href</span>=<span class="pl-s"><span class="pl-pds">"</span>../../iron-demo-helpers/demo-pages-shared-styles.html<span class="pl-pds">"</span></span>&gt; &lt;<span class="pl-ent">link</span> <span class="pl-e">rel</span>=<span class="pl-s"><span class="pl-pds">"</span>import<span class="pl-pds">"</span></span> <span class="pl-e">href</span>=<span class="pl-s"><span class="pl-pds">"</span>../../iron-icons/iron-icons.html<span class="pl-pds">"</span></span>&gt; &lt;<span class="pl-ent">link</span> <span class="pl-e">rel</span>=<span class="pl-s"><span class="pl-pds">"</span>import<span class="pl-pds">"</span></span> <span class="pl-e">href</span>=<span class="pl-s"><span class="pl-pds">"</span>../../paper-styles/color.html<span class="pl-pds">"</span></span>&gt; &lt;<span class="pl-ent">link</span> <span class="pl-e">rel</span>=<span class="pl-s"><span class="pl-pds">"</span>import<span class="pl-pds">"</span></span> <span class="pl-e">href</span>=<span class="pl-s"><span class="pl-pds">"</span>../paper-button.html<span class="pl-pds">"</span></span>&gt; &lt;<span class="pl-ent">next</span><span class="pl-e">-code-block</span>&gt;&lt;/<span class="pl-ent">next</span><span class="pl-e">-code-block</span>&gt; &lt;/<span class="pl-ent">template</span>&gt; &lt;/<span class="pl-ent">custom</span><span class="pl-e">-element-demo</span>&gt;</pre></div> <div class="highlight highlight-text-html-basic"><pre>&lt;<span class="pl-ent">paper</span><span class="pl-e">-button</span>&gt;Flat button&lt;/<span class="pl-ent">paper</span><span class="pl-e">-button</span>&gt; &lt;<span class="pl-ent">paper</span><span class="pl-e">-button</span> <span class="pl-e">raised</span>&gt;Raised button&lt;/<span class="pl-ent">paper</span><span class="pl-e">-button</span>&gt; &lt;<span class="pl-ent">paper</span><span class="pl-e">-button</span> <span class="pl-e">noink</span>&gt;No ripple effect&lt;/<span class="pl-ent">paper</span><span class="pl-e">-button</span>&gt; &lt;<span class="pl-ent">paper</span><span class="pl-e">-button</span> <span class="pl-e">toggles</span>&gt;Toggle-able button&lt;/<span class="pl-ent">paper</span><span class="pl-e">-button</span>&gt;</pre></div>';
+    });
 
+    test('Should create custom-element-demo', function() {
       var demos = Polymer.dom(readmeElement.root).querySelectorAll('custom-element-demo');
       assert.equal(demos.length, 1, 'one inline demo created');
       assert.equal(demos[0].getAttribute('height'), 500);
+    });
+
+    test('Should prevent demo from loading while docs pending', function() {
+      var demo = Polymer.dom(readmeElement.root).querySelectorAll('custom-element-demo')[0];
+      assert.isTrue(readmeElement.docsPending);
+      assert.isTrue(demo.docsPending);
+
+      var iframe = Polymer.dom(demo.root).querySelector('iframe');
+      expect(iframe.src).to.be.empty;
+
+      readmeElement.docsPending = false;
+      assert.isFalse(readmeElement.docsPending);
+      assert.isFalse(demo.docsPending);
+      expect(iframe.src).to.not.be.empty;
     });
   });
 
@@ -36,7 +53,8 @@
       readmeElement.data = {owner: 'owner', repo: 'repo', version: 'version'};
       readmeElement.baseUrls = {userContent:''};
     });
-    test('Should create custom-element-demo', function() {
+
+    test('Should rewrite links', function() {
       readmeElement.readme = '<img src="img.png">';
       var element = Polymer.dom(readmeElement.root).querySelector('img');
       assert.equal(element.getAttribute('src'), 'https://github.com/owner/repo/raw/master/img.png');


### PR DESCRIPTION
Since demos won't load correctly without the dependencies linked in the back-end, demos need to wait for docs before loading. This was broken because of the change notification timing & pending doc status responses.

Closes #892 