### PR TITLE
Analysis pathing fixes, rendering optimisations

### DIFF
--- a/analysis/src/analysis.js
+++ b/analysis/src/analysis.js
@@ -49,9 +49,9 @@ class Analysis {
         return this.bower.install(attributes.owner, attributes.repo, versionOrSha);
       }).then(mainHtmlPaths => {
         const root = path.resolve(process.cwd(), 'bower_components', attributes.repo);
-        if (!fs.existsSynnc(path)) {
+        if (!fs.existsSync(root)) {
           Ana.fail("analysis/processNextTask", taskAsString, "Installed package not found");
-          reject("Installed package not found");
+          reject({retry: false, erorr: Error("Installed package not found")});
           return;
         }
         var relativePaths = mainHtmlPaths.map(x => path.relative(root, x));

--- a/analysis/src/bower.js
+++ b/analysis/src/bower.js
@@ -73,7 +73,7 @@ class Bower {
             mainHtmls = [mainHtmls];
           }
 
-          resolve(mainHtmls.map(mainHtml => [canonicalDir, mainHtml].join("/"))); // eslint-disable-line no-loop-func
+          resolve({root: canonicalDir, mainHtmls: mainHtmls});
           return;
         }
         Ana.fail("bower/install", "Couldn't find package after installing [", packageToInstall, "] found [" + JSON.stringify(installed) + "]");

--- a/client/polymer.json
+++ b/client/polymer.json
@@ -6,7 +6,7 @@
     "src/catalog-community.html",
     "src/catalog-collection.html",
     "src/catalog-element.html",
-    "src/catalog-elements-analyzer.html",
+    "src/catalog-element-analyzer.html",
     "src/catalog-error.html",
     "src/catalog-preview-integration.html",
     "src/catalog-preview.html",

--- a/client/src/catalog-app.html
+++ b/client/src/catalog-app.html
@@ -494,16 +494,16 @@
       <catalog-search unresolved name="collections" page-title="Browse collections" query="kind:collection" base-urls="[[baseUrls(queryParams)]]"></catalog-search>
       <catalog-error unresolved name="error" id="error"></catalog-error>
 
-      <catalog-static name="about" page-title="About webcomponents.org"></catalog-static>
-      <catalog-static name="assets" page-title="webcomponents.org assets"></catalog-static>
-      <catalog-static name="introduction" page-title="Introduction"></catalog-static>
-      <catalog-static name="polyfills" page-title="Polyfills"></catalog-static>
-      <catalog-static name="resources" page-title="Resources"></catalog-static>
-      <catalog-static name="specs" page-title="Specifications"></catalog-static>
-      <catalog-static name="libraries" page-title="Libraries"></catalog-static>
-      <catalog-static name="launch-announcement" page-title="Introducing the new element registry"></catalog-static>
+      <catalog-static unresolved name="about" page-title="About webcomponents.org"></catalog-static>
+      <catalog-static unresolved name="assets" page-title="webcomponents.org assets"></catalog-static>
+      <catalog-static unresolved name="introduction" page-title="Introduction"></catalog-static>
+      <catalog-static unresolved name="polyfills" page-title="Polyfills"></catalog-static>
+      <catalog-static unresolved name="resources" page-title="Resources"></catalog-static>
+      <catalog-static unresolved name="specs" page-title="Specifications"></catalog-static>
+      <catalog-static unresolved name="libraries" page-title="Libraries"></catalog-static>
+      <catalog-static unresolved name="launch-announcement" page-title="Introducing the new element registry"></catalog-static>
 
-      <catalog-community name="community" path="[[_filter('/community', subroute.prefix, subroute.path)]]"></catalog-community>
+      <catalog-community unresolved name="community" path="[[_filter('/community', subroute.prefix, subroute.path)]]"></catalog-community>
     </iron-pages>
 
     <footer role="contentinfo">

--- a/client/src/catalog-element-readme.html
+++ b/client/src/catalog-element-readme.html
@@ -271,7 +271,7 @@
         }
 
         if (this._codeBlocks.length)
-          this.async(this._updateCodeBlock);
+          this.async(this._updateCodeBlocks);
       },
 
       attached: function() {

--- a/client/src/catalog-element-readme.html
+++ b/client/src/catalog-element-readme.html
@@ -212,11 +212,29 @@
         // Only scope once so inline demos don't have conflicting styles.
         this.scopeSubtree(this.$.contents, false);
 
-        var codeBlocks = [].slice.call(Polymer.dom(this.root).querySelectorAll('pre'));
+        this._codeBlocks = [].slice.call(Polymer.dom(this.root).querySelectorAll('pre'));
+        this._updateCodeBlocks();
+
+        var githubBase = 'https://github.com/' + data.owner + '/' + data.repo;
+        var relativeRegex = /^(?!http|#|\/\/)\/?(.*$)/;
+        var i;
+
+        var links = Polymer.dom(this.$.contents).querySelectorAll('[href]');
+        var defaultBranch = data.default_branch || 'master';
+        for (i = 0; i < links.length; i++)
+          links[i].setAttribute('href', links[i].getAttribute('href').replace(relativeRegex, githubBase + '/blob/' + defaultBranch + '/$1'));
+
+        links = Polymer.dom(this.$.contents).querySelectorAll('[src]');
+        for (i = 0; i < links.length; i++)
+          links[i].setAttribute('src', links[i].getAttribute('src').replace(relativeRegex, githubBase + '/raw/' + defaultBranch + '/$1'));
+      },
+
+      _updateCodeBlocks: function() {
+        var t = performance.now();
 
         // Find and replace all inline demos.
-        while (codeBlocks.length) {
-          var block = codeBlocks.shift();
+        while (this._codeBlocks.length && performance.now() - t < 50) {
+          var block = this._codeBlocks.shift();
           var demoMatch = block.textContent.match(/<custom-element-demo[^]*?>[^]*<\/custom-element-demo>/);
           if (!demoMatch)
             continue;
@@ -239,8 +257,8 @@
           code = code.replace(/^\n/, "").replace(/^ {4}/gm, '').replace(/\n\s*$/, '');
           var nextBlockRegex = /<next-code-block><\/next-code-block>/;
           var snippet = '';
-          if (code.match(nextBlockRegex) && codeBlocks.length) {
-            var nextBlock = codeBlocks.shift();
+          if (code.match(nextBlockRegex) && this._codeBlocks.length) {
+            var nextBlock = this._codeBlocks.shift();
             snippet = nextBlock.textContent;
             if (nextBlock.parentNode)
               nextBlock.parentNode.removeChild(nextBlock);
@@ -252,18 +270,8 @@
           demoElement.code = code;
         }
 
-        var githubBase = 'https://github.com/' + data.owner + '/' + data.repo;
-        var relativeRegex = /^(?!http|#|\/\/)\/?(.*$)/;
-        var i;
-
-        var links = Polymer.dom(this.$.contents).querySelectorAll('[href]');
-        var defaultBranch = data.default_branch || 'master';
-        for (i = 0; i < links.length; i++)
-          links[i].setAttribute('href', links[i].getAttribute('href').replace(relativeRegex, githubBase + '/blob/' + defaultBranch + '/$1'));
-
-        links = Polymer.dom(this.$.contents).querySelectorAll('[src]');
-        for (i = 0; i < links.length; i++)
-          links[i].setAttribute('src', links[i].getAttribute('src').replace(relativeRegex, githubBase + '/raw/' + defaultBranch + '/$1'));
+        if (this._codeBlocks.length)
+          this.async(this._updateCodeBlock);
       },
 
       attached: function() {

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -741,6 +741,8 @@
         this.fire('meta-set', {key: 'property', value: 'og:url', content: document.location.href});
         this.fire('meta-set', {key: 'property', value: 'og:image', content: this.data.avatar_url});
         this.fire('meta-set', {key: 'name', value: 'twitter:card', content: 'summary'});
+
+        this.async(this._updateActiveLinks);
       },
 
       _pageTitle: function(pages, pagePath) {


### PR DESCRIPTION
Apparently jumped the gun in several places. This change:
 * Fixes analysis pathing assumptions. The `bower` component now returns the directory it installed in, for use by the `analyzer` component later.
 * Fixes polymer build, which had a typo which wasn't picked up in the chain.
 * Fixes #929, where `unresolved` wasn't applied everywhere, causing some pages to not load, introduced by #923 which hot-swaps `<catalog-element>`.
 * Introduces batched inline demo rendering to readme pages. This brings rendering performance in line with network performance, while previously a large number of inline demos could block rendering for several seconds.
 * Fixes active link in sidebar on a custom page load.