### PR TITLE
Support analyzer output

### DIFF
--- a/client/bower.json
+++ b/client/bower.json
@@ -12,11 +12,10 @@
     "marked": "~0.3.3",
     "paper-spinner": "PolymerElements/paper-spinner#^1.2.0",
     "paper-toast": "PolymerElements/paper-toast#^1.3.0",
-    "polymer": "Polymer/polymer#^1.4.0"
+    "polymer": "Polymer/polymer#^1.4.0",
+    "iron-doc-viewer": "PolymerElements/iron-doc-viewer#2.0-analyzer"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
     "web-component-tester": "^5.0.1",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }

--- a/client/src/catalog-element-analyzer.html
+++ b/client/src/catalog-element-analyzer.html
@@ -790,21 +790,21 @@
         // Walks through the tree of namespaces to find the namespace
         // containing `name`.
         function getNamespace(descriptor, name) {
-          var parts = name.split('.');
-          if (parts.length < 2) {
-            return undefined;
+          function match(name, namespace) {
+            return namespace.name == name;
           }
+
+          var parts = name.split('.');
+          if (parts.length < 2)
+            return undefined;
+
           var namespace = descriptor;
           for (var i = 0; i < parts.length - 1; i++) {
-            if (!namespace.namespaces) {
+            if (!namespace.namespaces)
               return undefined;
-            }
-            var matches = namespace.namespaces.filter(function(n) {
-              return n.name === parts[i];
-            });
-            if (matches.length === 0) {
+            var matches = namespace.namespaces.filter(match.bind(null, parts[i]));
+            if (!matches.length)
               return undefined;
-            }
             namespace = matches[0];
           }
           return namespace;

--- a/client/src/catalog-element-analyzer.html
+++ b/client/src/catalog-element-analyzer.html
@@ -949,7 +949,7 @@
       },
 
       _hasActiveLink: function() {
-        return !!this.querySelector('.sidebar-nav a[active]');
+        return Boolean(this.querySelector('.sidebar-nav a[active]'));
       },
 
       _updateActiveLinks: function() {

--- a/client/src/catalog-element-analyzer.html
+++ b/client/src/catalog-element-analyzer.html
@@ -317,6 +317,7 @@
 
     <iron-ajax
       id="pageAjax"
+      loading="{{_customPageLoading}}"
       url="[[baseUrls.api]]/api/page/[[owner]]/[[repo]]/[[data.version]]/[[pagePath]]"
       handle-as="text"
       last-response="{{_customPage}}"></iron-ajax>
@@ -355,18 +356,12 @@
 
             <template is="dom-repeat" items="[[docs.analysis.namespaces]]" as="namespace">
               <a class="api-link" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/namespaces/[[namespace.name]]"><span>[[namespace.name]]</span></a>
-
-              <div class="element-demos" role="navigation" aria-label$="[[element.is]] demos">
-                <template is="dom-repeat" items="[[element.demos]]" as="demo">
-                  <a class="demo-link sub-item" rel="nofollow" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/demo/[[demo.path]]" on-click="_demoClicked"><span>Demo</span></a>
-                </template>
-              </div>
             </template>
 
             <template is="dom-repeat" items="[[bundledElements]]" as="element">
               <a class="api-link" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/elements/[[element.tagname]]"><span>&lt;[[element.tagname]]&gt;</span></a>
 
-              <div class="element-demos" role="navigation" aria-label$="[[element.is]] demos">
+              <div class="element-demos" role="navigation" aria-label$="[[element.tagname]] demos">
                 <template is="dom-repeat" items="[[element.demos]]" as="demo">
                   <a class="demo-link sub-item" rel="nofollow" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/demo/[[demo.path]]" on-click="_demoClicked"><span>Demo</span></a>
                 </template>
@@ -448,7 +443,7 @@
             <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!docs]]" readme="[[data.readme]]" base-urls="[[baseUrls]]" hidden="[[_or(subElement, pagePath)]]"></catalog-element-readme>
           </template>
           <template is="dom-if" if="[[pagePath]]">
-            <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!docs]]" readme="[[_customPage]]" base-urls="[[baseUrls]]"></catalog-element-readme>
+            <catalog-element-readme editing="[[_shouldShowEditor(queryParams, route.prefix)]]" data="[[data]]" docs-pending="[[!docs]]" readme="[[_customPage]]" base-urls="[[baseUrls]]" class="loader" loading="_customPageLoading"></catalog-element-readme>
           </template>
 
           <div hidden="[[!subElement]]">
@@ -524,7 +519,7 @@
           return;
 
         this.data = null;
-        delete this.descriptor;
+        delete this._descriptor;
         this.bundledElements = [];
         this.bundledBehaviors = [];
         this.dupedDemos = [];
@@ -594,6 +589,8 @@
         if (!this.data || this._currentOwner != this.owner || this._currentRepo != this.repo || this._currentVersionRoute != this.versionRoute) {
           // Trigger a microtask to ensure change notifications are completed.
           this.debounce('_updatePath', this._updatePath);
+        } else if (this.pagePath) {
+          this.$.pageAjax.generateRequest();
         }
 
         this._updateDescriptor();
@@ -715,6 +712,8 @@
         this.fire('meta-set', {key: 'property', value: 'og:url', content: document.location.href});
         this.fire('meta-set', {key: 'property', value: 'og:image', content: this.data.avatar_url});
         this.fire('meta-set', {key: 'name', value: 'twitter:card', content: 'summary'});
+
+        this.async(this._updateActiveLinks);
       },
 
       _pageTitle: function(pages, pagePath) {
@@ -770,7 +769,8 @@
           return;
         this.bundledElements = this._elements();
         this.bundledBehaviors = this._behaviors();
-        this.dupedDemos = this._dedupeDemos(this._bowerDemos, this.bundledElements, this.bundledBehaviors);
+        // TODO: Support deduping of demos. Analyzer currently doesn't support demo titles.
+        // this.dupedDemos = this._dedupeDemos(this._bowerDemos, this.bundledElements, this.bundledBehaviors);
 
         var map = new Map();
         this.bundledElements.forEach(function(element) {
@@ -823,15 +823,9 @@
           return;
         }
 
-        var name = this.subElement;
-        var namespace = getNamespace(this.docs.analysis, name) || this.docs.analysis;
-        if (this._descriptorType == 'namespaces') {
-          this._descriptor = getByName(namespace.namespaces, this.subElement);
-        } else if (this._descriptorType == 'elements') {
-          this._descriptor = getByName(namespace.elements, this.subElement);
-        } else if (this._descriptorType == 'mixins') {
-          this._descriptor = getByName(namespace.mixins, this.subElement);
-        }
+        var namespace = getNamespace(this.docs.analysis, this.subElement) || this.docs.analysis;
+        if (this._descriptorType)
+          this._descriptor = getByName(namespace[this._descriptorType], this.subElement);
 
         // Support legacy pathing and find descriptor type. Also necessary for
         // behaviors in a different path to mixins.
@@ -845,6 +839,9 @@
 
         if (!this._descriptor)
           console.error('No descriptor found!');
+
+        if (!this._hasActiveLink() && Polymer.AppLayout)
+          Polymer.AppLayout.scroll(0);
       },
 
       _elements: function() {
@@ -949,6 +946,10 @@
 
       _or: function(a, b) {
         return a || b;
+      },
+
+      _hasActiveLink: function() {
+        return !!this.querySelector('.sidebar-nav a[active]');
       },
 
       _updateActiveLinks: function() {

--- a/client/src/catalog-element-analyzer.html
+++ b/client/src/catalog-element-analyzer.html
@@ -794,14 +794,13 @@
           if (parts.length < 2) {
             return undefined;
           }
-          parts = parts.slice(0, parts.length - 1);
           var namespace = descriptor;
-          for (var part of parts) {
+          for (var i = 0; i < parts.length - 1; i++) {
             if (!namespace.namespaces) {
               return undefined;
             }
             var matches = namespace.namespaces.filter(function(n) {
-              return n.name === part;
+              return n.name === parts[i];
             });
             if (matches.length === 0) {
               return undefined;

--- a/client/src/catalog-element-analyzer.html
+++ b/client/src/catalog-element-analyzer.html
@@ -3,9 +3,11 @@
 <link rel="import" href="../bower_components/app-route/app-location.html">
 <link rel="import" href="../bower_components/app-route/app-route.html">
 <link rel="import" href="../bower_components/iron-ajax/iron-ajax.html">
+<link rel="import" href="../bower_components/iron-doc-viewer/iron-doc-element.html">
+<link rel="import" href="../bower_components/iron-doc-viewer/iron-doc-namespace.html">
+<link rel="import" href="../bower_components/iron-doc-viewer/iron-doc-mixin.html">
 
 <link rel="import" href="catalog-styles.html">
-<link rel="import" href="catalog-api-doc.html">
 <link rel="import" href="catalog-element-readme.html">
 <link rel="import" href="collection-card.html">
 <link rel="import" href="github-info.html">
@@ -351,8 +353,18 @@
               <a class="page-link" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/page/[[page.path]]"><span>[[page.title]]</span></a>
             </template>
 
+            <template is="dom-repeat" items="[[docs.analysis.namespaces]]" as="namespace">
+              <a class="api-link" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/namespaces/[[namespace.name]]"><span>[[namespace.name]]</span></a>
+
+              <div class="element-demos" role="navigation" aria-label$="[[element.is]] demos">
+                <template is="dom-repeat" items="[[element.demos]]" as="demo">
+                  <a class="demo-link sub-item" rel="nofollow" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/demo/[[demo.path]]" on-click="_demoClicked"><span>Demo</span></a>
+                </template>
+              </div>
+            </template>
+
             <template is="dom-repeat" items="[[bundledElements]]" as="element">
-              <a class="api-link" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/[[element.tagname]]"><span>&lt;[[element.tagname]]&gt;</span></a>
+              <a class="api-link" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/elements/[[element.tagname]]"><span>&lt;[[element.tagname]]&gt;</span></a>
 
               <div class="element-demos" role="navigation" aria-label$="[[element.is]] demos">
                 <template is="dom-repeat" items="[[element.demos]]" as="demo">
@@ -362,7 +374,7 @@
             </template>
 
             <template is="dom-repeat" items="[[bundledBehaviors]]" as="behavior">
-              <a class="api-link" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/[[behavior.name]]"><span>[[behavior.name]]</span></a>
+              <a class="api-link" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/mixins/[[behavior.name]]"><span>[[behavior.name]]</span></a>
 
               <div class="element-demos">
                 <template is="dom-repeat" items="[[behavior.demos]]" as="demo">
@@ -440,8 +452,23 @@
           </template>
 
           <div hidden="[[!subElement]]">
-            <h1>[[_docTitle(subElement, descriptor)]]</h1>
-            <catalog-api-doc descriptor="[[descriptor]]"></catalog-api-doc>
+            <template is="dom-if" if="[[_equal(_descriptorType,'namespaces')]]" restamp="true">
+              <iron-doc-namespace
+                  base-href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]"
+                  descriptor="[[_descriptor]]"
+                  root-namespace="[[rootNamespace]]">
+              </iron-doc-namespace>
+            </template>
+            <template is="dom-if" if="[[_equal(_descriptorType,'elements')]]" restamp="true">
+              <iron-doc-element
+                base-href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]"
+                descriptor="[[_descriptor]]"></iron-doc-element>
+            </template>
+            <template is="dom-if" if="[[_equal(_descriptorType,'mixins')]]" restamp="true">
+              <iron-doc-mixin
+                base-href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]"
+                descriptor="[[_descriptor]]"></iron-doc-mixin>
+            </template>
           </div>
         </div>
       </div>
@@ -536,6 +563,10 @@
           this.pagePath = split.join('/');
           split = [];
         }
+
+        var descriptorTypes = ['namespaces', 'elements', 'mixins'];
+        if (split.length && descriptorTypes.indexOf(split[0]) != -1)
+          this._descriptorType = split.shift();
 
         if (split.length)
           this.subElement = split.shift();
@@ -717,7 +748,7 @@
       _docsResponse: function() {
         this._unblockLazy();
         this.$['sidebar-spinner'].removeAttribute('active');
-        this._updateDescriptor();
+        this._populateDocs();
         this.async(this._updateActiveLinks);
       },
 
@@ -734,16 +765,87 @@
         }
       },
 
-      _updateDescriptor: function() {
-        this._hasRepoContents = false;
-        if (!this.docs || (!this.docs.content && !this.docs.analysis))
+      _populateDocs: function() {
+        if (!this.docs || !this.docs.analysis)
           return;
         this.bundledElements = this._elements();
         this.bundledBehaviors = this._behaviors();
-        if (!this.dupedDemos || !this.dupedDemos.length)
-          this.dupedDemos = this._dedupeDemos(this._bowerDemos, this.bundledElements, this.bundledBehaviors);
-        this._hasRepoContents = this.bundledElements.length || this.bundledBehaviors.length || this.dupedDemos.length;
-        // TODO(samli): find matching descriptor for this.subElement
+        this.dupedDemos = this._dedupeDemos(this._bowerDemos, this.bundledElements, this.bundledBehaviors);
+
+        var map = new Map();
+        this.bundledElements.forEach(function(element) {
+          map.set(element.tagname, element);
+        });
+        this._elementMap = map;
+        map = new Map();
+        this.bundledBehaviors.forEach(function(behavior) {
+          map.set(behavior.name, behavior);
+        });
+        this._behaviorMap = map;
+
+        this._updateDescriptor();
+      },
+
+      _updateDescriptor: function() {
+        // Walks through the tree of namespaces to find the namespace
+        // containing `name`.
+        function getNamespace(descriptor, name) {
+          var parts = name.split('.');
+          if (parts.length < 2) {
+            return undefined;
+          }
+          parts = parts.slice(0, parts.length - 1);
+          var namespace = descriptor;
+          for (var part of parts) {
+            if (!namespace.namespaces) {
+              return undefined;
+            }
+            var matches = namespace.namespaces.filter(function(n) {
+              return n.name === part;
+            });
+            if (matches.length === 0) {
+              return undefined;
+            }
+            namespace = matches[0];
+          }
+          return namespace;
+        }
+
+        function getByName(list, value) {
+          var match = list && list.filter(function(x) {
+            return x.name == value || x.classname == value || x.tagname == value;
+          });
+          return match && match.length && match[0];
+        }
+
+        Polymer.dom.flush();
+        if (!this.subElement || !this.docs || !this.docs.analysis) {
+          delete this._descriptor;
+          return;
+        }
+
+        var name = this.subElement;
+        var namespace = getNamespace(this.docs.analysis, name) || this.docs.analysis;
+        if (this._descriptorType == 'namespaces') {
+          this._descriptor = getByName(namespace.namespaces, this.subElement);
+        } else if (this._descriptorType == 'elements') {
+          this._descriptor = getByName(namespace.elements, this.subElement);
+        } else if (this._descriptorType == 'mixins') {
+          this._descriptor = getByName(namespace.mixins, this.subElement);
+        }
+
+        // Support legacy pathing and find descriptor type. Also necessary for
+        // behaviors in a different path to mixins.
+        if (!this._descriptor && this._elementMap.has(this.subElement)) {
+          this._descriptorType = 'elements';
+          this._descriptor = this._elementMap.get(this.subElement);
+        } else if (!this._descriptor && this._behaviorMap.has(this.subElement)) {
+          this._descriptorType = 'mixins';
+          this._descriptor = this._behaviorMap.get(this.subElement);
+        }
+
+        if (!this._descriptor)
+          console.error('No descriptor found!');
       },
 
       _elements: function() {
@@ -916,10 +1018,6 @@
 
         xhr.open('POST', this.baseUrls.api + '/api/star/' + this.owner + '/' + this.repo + '?code=' + this.queryParams.code);
         xhr.send();
-      },
-
-      _docTitle: function(subElement, descriptor) {
-        return descriptor && descriptor.type == 'element' ? '<' + subElement + '>' : subElement;
       },
 
       _redundantLink: function(link) {

--- a/client/test/catalog-element-analyzer.html
+++ b/client/test/catalog-element-analyzer.html
@@ -1,0 +1,160 @@
+<!doctype html>
+
+<script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+<script src="../bower_components/web-component-tester/browser.js"></script>
+
+<!-- Import the element to test -->
+<link rel="import" href="../src/catalog-element-analyzer.html">
+
+<test-fixture id="element-page">
+  <template>
+     <catalog-element></catalog-element>
+  </template>
+</test-fixture>
+
+<script>
+  suite('Element test', function() {
+    var stashedStars;
+    var elementPage;
+    var responseHeaders = {
+      json: {'Content-Type': 'application/json'}
+    };
+    var metaResponse = {
+      "status": "ready",
+      "kind": "element",
+      "contributors": [],
+      "avatar_url": "https://avatars.githubusercontent.com/u/787668?v=3",
+      "updated_at": "2016-07-14T05:53:05Z",
+      "repo": "repoName",
+      "readme": "readme",
+      "bower": {
+        "keywords": [
+          "web-components",
+          "polymer",
+          "card"
+        ],
+        "dependencies": {
+          "polymer": "Polymer/polymer#^1.1.0"
+        },
+        "description": "description",
+        "license": "license"
+      },
+      "subscribers": 1,
+      "owner": "ownerName",
+      "versions": [
+        "v1.0.0"
+      ],
+      "version": "v1.0.0",
+      "collections": [],
+      "stars": 0,
+      "open_issues": 0,
+      "forks": 0
+    };
+
+    setup(function() {
+      server = sinon.fakeServer.create();
+      server.respondWith(
+        'GET',
+        /\/api\/meta\/.*/, [
+          200,
+          responseHeaders.json,
+          JSON.stringify(metaResponse)
+        ]
+      );
+      server.respondWith(
+        'POST',
+        /\/api\/star\/.*/, [204, '', '']
+      );
+      stashedStars = window.localStorage.starredRepos;
+      delete window.localStorage.starredRepos;
+    });
+
+    teardown(function() {
+      server.restore();
+      if (stashedStars)
+        window.localStorage.starredRepos = stashedStars;
+    });
+
+    test('api/meta readme displayed on page', function(done) {
+      elementPage = fixture('element-page');
+      elementPage.baseUrls = {api: '', userContent: ''};
+      elementPage.route = {path: '/owner/repo', prefix: '/element'};
+      elementPage.setAttribute('visible', '');
+      elementPage.flushDebouncer('_updatePath');
+      server.respond();
+      elementPage.$.metaAjax.addEventListener('response', function() {
+        flush(function() {
+          var readmeElement = Polymer.dom(elementPage.root).querySelector('catalog-element-readme');
+          var readmeContents = Polymer.dom(readmeElement.root).querySelector('#contents');
+          assert.notEqual(readmeContents.textContent.indexOf('readme'), -1);
+          done();
+        });
+      });
+    });
+
+    test('_isStarred and _setStarred', function() {
+      elementPage = fixture('element-page');
+      elementPage.baseUrls = {api: '', userContent: ''};
+      elementPage.route = {path: '/owner/repo', prefix: '/element'};
+      elementPage.setAttribute('visible', '');
+      elementPage.flushDebouncer('_updatePath');
+      server.respond();
+      assert(!elementPage._isStarred(), 'should not be starred');
+      elementPage._setStarred(false);
+      assert(elementPage._isStarred(), 'should be starred');
+    });
+
+    test('starred API call', function(done) {
+      elementPage = fixture('element-page');
+      elementPage.baseUrls = {api: '', userContent: ''};
+      elementPage.route = {path: '/owner/repo', prefix: '/element'};
+      elementPage.setAttribute('visible', '');
+      elementPage.queryParams = {code: 'fakeCode'};
+      elementPage.flushDebouncer('_updatePath');
+      server.respond();
+
+      elementPage.$.metaAjax.addEventListener('response', function() {
+        flush(function() {
+          assert(!elementPage._isStarred(), 'should not be starred');
+          assert.equal(elementPage.data.stars, 0);
+          elementPage._starRepo();
+          server.respond();
+          assert(elementPage._isStarred(), 'should be starred');
+          assert.equal(elementPage.data.stars, 1);
+          done();
+        });
+      });
+    });
+
+    test('dedupeDemos()', function() {
+      elementPage = fixture('element-page');
+
+      function gen() {
+        var result = [];
+        for (var i = 0; i < arguments.length; i++)
+          result.push({path: arguments[i] + '.html'})
+        return result;
+      }
+
+      function genElement() {
+        return [{demos: gen.apply(null, arguments)}];
+      }
+
+      expect(elementPage._dedupeDemos([], [], [])).to.be.empty;
+      expect(elementPage._dedupeDemos(gen('a'), genElement('b'), genElement('c'))).to.be.empty;
+
+      var elements = genElement('b', 'c');
+      var behaviors = genElement('b');
+      expect(elementPage._dedupeDemos(gen('a'), elements, behaviors)).to.eql(gen('b'));
+      expect(elements).to.eql(genElement('c'));
+      expect(behaviors).to.eql(genElement());
+
+      elements = genElement('element', 'shared');
+      behaviors = genElement('bowera', 'shared', 'behavior');
+      expect(elementPage._dedupeDemos(gen('bowera', 'bowerb'), elements, behaviors)).to.eql(gen('shared'));
+      expect(elements).to.eql(genElement('element'));
+      expect(behaviors).to.eql(genElement('behavior'));
+    });
+
+  });
+</script>


### PR DESCRIPTION
Part of #913.

 * Updates pathing to include type of documentation, `namespace`, `element` or `mixin`.
 * Supports legacy 1.x pathing (no type in pathing)
 * Supports all of Polymer documentation under a single namespace `Polymer` in the sidebar. This matches behavior on the [main Polymer docs site](https://www.polymer-project.org/2.0/docs/api/). Hard to place in the sidebar since namespaces are nested.
 * Comparison of loading bundle sizes:
```
127K catalog-element-analyzer.html
35K catalog-element.html
```
 * Merge changes from `catalog-element` to `catalog-element-analyzer`.
