### PR TITLE
Add clipboard copy for #480

### DIFF
--- a/client/src/catalog-app.html
+++ b/client/src/catalog-app.html
@@ -594,6 +594,7 @@
         this.$.toast.text = options.message;
         this.$.toastAction.textContent = options.buttonText;
         this.$.toast.duration = options.duration == null ? 5000 : options.duration;
+        this.$.toast.removeAttribute('opened'); // In case it was previously set
         this.$.toast.setAttribute('opened', '');
 
         this._currentToast = options;

--- a/client/src/catalog-app.html
+++ b/client/src/catalog-app.html
@@ -593,6 +593,7 @@
         var options = event.detail;
         this.$.toast.text = options.message;
         if (options.hasOwnProperty('buttonText')) {
+          this.$.toastAction.removeAttribute('hidden');
           this.$.toastAction.textContent = options.buttonText;
         } else {
           this.$.toastAction.setAttribute('hidden', '');

--- a/client/src/catalog-app.html
+++ b/client/src/catalog-app.html
@@ -592,7 +592,11 @@
       _notifyUser: function(event) {
         var options = event.detail;
         this.$.toast.text = options.message;
-        this.$.toastAction.textContent = options.buttonText;
+        if (options.hasOwnProperty('buttonText')) {
+          this.$.toastAction.textContent = options.buttonText;
+        } else {
+          this.$.toastAction.setAttribute('hidden', '')
+        }
         this.$.toast.duration = options.duration == null ? 5000 : options.duration;
         this.$.toast.removeAttribute('opened'); // In case it was previously set
         this.$.toast.setAttribute('opened', '');

--- a/client/src/catalog-app.html
+++ b/client/src/catalog-app.html
@@ -595,7 +595,7 @@
         if (options.hasOwnProperty('buttonText')) {
           this.$.toastAction.textContent = options.buttonText;
         } else {
-          this.$.toastAction.setAttribute('hidden', '')
+          this.$.toastAction.setAttribute('hidden', '');
         }
         this.$.toast.duration = options.duration == null ? 5000 : options.duration;
         this.$.toast.removeAttribute('opened'); // In case it was previously set

--- a/client/src/github-info.html
+++ b/client/src/github-info.html
@@ -290,7 +290,7 @@
           window.getSelection().addRange(range);
         }
 
-        if (document.execCommand('copy')){
+        if (document.execCommand('copy')) {
           this.fire('notify', {
             message: 'Install command copied to clipboard'
           });

--- a/client/src/github-info.html
+++ b/client/src/github-info.html
@@ -289,6 +289,12 @@
           window.getSelection().removeAllRanges();
           window.getSelection().addRange(range);
         }
+
+        if (document.execCommand('copy')){
+          this.fire('notify', {
+            message: 'Install command copied to clipboard'
+          });
+        }
       },
 
       _searchTag: function(event) {


### PR DESCRIPTION
Copying was straightforward, the `document.execCommand('copy')` command appears to be [supported in modern browsers](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#Browser_compatibility).

However there is one weird thing about this.  If you click the bower command then it becomes selected, copied, and you see the toast.  If you select something else and then select the bower command *again*, the text again gets copied to your clipboard but you do **not** see the toast a second time.  I verified that the copy was happening by testing with a `concole.log("COPY")` on line 294.  

I also verified that the `notify` event is firing by adding another log in the [handler](https://github.com/webcomponents/webcomponents.org/blob/master/client/src/catalog-app.html#L592) so this seems to be an issue with the toast.  Should I not use the toast at all for this, or try to fix it?