### PR TITLE
Don't load re-captcha everywhere, reduces network load by 20%

### DIFF
--- a/client/polymer.json
+++ b/client/polymer.json
@@ -16,7 +16,8 @@
     "src/catalog-static.html",
     "src/catalog-home.html",
     "src/code-editor.html",
-    "src/lazy-resources.html"
+    "src/lazy-resources.html",
+    "src/re-captcha.html"
   ],
   "extraDependencies": [
     "assets/**/*",

--- a/client/src/catalog-preview.html
+++ b/client/src/catalog-preview.html
@@ -67,6 +67,10 @@
         Polymer.PollingMetaBehavior,
       ],
 
+      created: function() {
+        this.importHref(this.resolveUrl('re-captcha.html'), null, null, true);
+      },
+
       onSubmit: function() {
         if (this.$.submit.hasAttribute('disabled') || !this.$.recaptcha.getResponse())
           return;

--- a/client/src/catalog-publish-collection.html
+++ b/client/src/catalog-publish-collection.html
@@ -69,6 +69,10 @@
         Polymer.PollingMetaBehavior,
       ],
 
+      created: function() {
+        this.importHref(this.resolveUrl('re-captcha.html'), null, null, true);
+      },
+
       onSubmit: function() {
         if (this.$.submit.hasAttribute('disabled') || !this.$.recaptcha.getResponse())
           return;

--- a/client/src/catalog-publish.html
+++ b/client/src/catalog-publish.html
@@ -246,6 +246,10 @@
         Polymer.PollingMetaBehavior,
       ],
 
+      created: function() {
+        this.importHref(this.resolveUrl('re-captcha.html'), null, null, true);
+      },
+
       ready: function() {
         var sample = this.$['sample-demo'];
         sample.data = {

--- a/client/src/lazy-resources.html
+++ b/client/src/lazy-resources.html
@@ -3,7 +3,6 @@
 <link rel="import" href="contributors-list.html">
 <link rel="import" href="activity-graph.html">
 <link rel="import" href="catalog-dialog.html">
-<link rel="import" href="re-captcha.html">
 <link rel="import" href="spinner-lite.html">
 <link rel="import" href="browser-table.html">
 <link rel="import" href="../bower_components/paper-toast/paper-toast.html">


### PR DESCRIPTION
While `<re-captcha>` is < 1KB, the actual scripts it loads are 80kb+.

This changes so its only loaded on routes that need it. It brings a full page network load from 371kb to 290kb, which is a 20% improvement.