### PR TITLE
Fix API doc error

### DIFF
--- a/client/src/catalog-api-property.html
+++ b/client/src/catalog-api-property.html
@@ -194,7 +194,7 @@
         <span id="type" class="type">{{descriptor.type}}</span>
         <span class="annotation">[[_getAnnotation(descriptor)]]</span>
       </div>
-      <ol id="params" hidden$="{{_computeHideParams(descriptor,descriptor.return)}}">
+      <ol id="params" hidden$="{{_computeHideParams(descriptor, descriptor.return)}}">
         <template is="dom-repeat" items="{{descriptor.params}}">
           <li hidden$="{{!item.type}}">
             <span class="name">{{item.name}}</span>

--- a/client/src/catalog-api-property.html
+++ b/client/src/catalog-api-property.html
@@ -194,7 +194,7 @@
         <span id="type" class="type">{{descriptor.type}}</span>
         <span class="annotation">[[_getAnnotation(descriptor)]]</span>
       </div>
-      <ol id="params" hidden$="{{_computeHideParams(descriptor.return)}}">
+      <ol id="params" hidden$="{{_computeHideParams(descriptor,descriptor.return)}}">
         <template is="dom-repeat" items="{{descriptor.params}}">
           <li hidden$="{{!item.type}}">
             <span class="name">{{item.name}}</span>

--- a/client/src/syntax-highlighter.html
+++ b/client/src/syntax-highlighter.html
@@ -79,7 +79,7 @@
       CodeMirror.runMode(text, lang || 'htmlmixed', element);
 
       // Try javascript highlighting instead
-      if (!lang || !element.firstElementChild)
+      if (!lang && !element.firstElementChild)
         CodeMirror.runMode(text, 'javascript', element);
       element.classList.add('cm-s-default');
     },


### PR DESCRIPTION
Regressed in #935, where an error was picked up in the new build, but I fixed it incorrectly.

Considered adding a test, but this is for our hydrolysis docs which I hope to soon no longer use.

Also fixes syntax highlighting in the guessing language case.