### PR TITLE
Compress analyzer data before storing it

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -344,7 +344,7 @@ class GetDocs(webapp2.RequestHandler):
     result = {}
     result['status'] = analysis.status
     if analysis.status == Status.ready:
-      content = json.loads(analysis.content)
+      content = json.loads(analysis.get_content())
 
       has_analyzer_data = content.get('analyzerData', None) is not None
 

--- a/src/api.py
+++ b/src/api.py
@@ -194,7 +194,7 @@ class LibraryMetadata(object):
 
     bower = yield bower_future
     if bower is not None:
-      bower_json = json.loads(bower.content)
+      bower_json = bower.get_json()
       dependencies = bower_json.get('dependencies', {})
       result['dependency_count'] = len(dependencies)
       result['bower'] = {
@@ -262,7 +262,7 @@ class GetDependencies(webapp2.RequestHandler):
       self.response.set_status(404)
       return
 
-    bower_json = json.loads(bower.content)
+    bower_json = bower.get_json()
     bower_dependencies = bower_json.get('dependencies', {})
 
     dependencies = []
@@ -344,7 +344,7 @@ class GetDocs(webapp2.RequestHandler):
     result = {}
     result['status'] = analysis.status
     if analysis.status == Status.ready:
-      content = json.loads(analysis.get_content())
+      content = analysis.get_json()
 
       has_analyzer_data = content.get('analyzerData', None) is not None
 

--- a/src/api_test.py
+++ b/src/api_test.py
@@ -5,7 +5,6 @@ import webtest
 from datamodel import Library, Version, Content, Status
 from api import app
 import util
-import zlib
 
 from test_base import TestBase
 
@@ -155,7 +154,7 @@ class DocsTest(ApiTestBase):
     version_key = Version(id='v1.1.1', parent=library_key, sha='sha', status='ready').put()
 
     content = Content(id='analysis', parent=version_key, status=Status.pending)
-    content.content_compressed = zlib.compress(json.dumps({"analyzerData":"some data"}))
+    content.json = dict({"analyzerData": "some data"})
     content.status = Status.ready
     content.put()
 

--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -2,6 +2,7 @@ from google.appengine.ext import ndb
 
 import re
 import versiontag
+import zlib
 
 class CollectionReference(ndb.Model):
   semver = ndb.StringProperty(indexed=False)
@@ -154,11 +155,17 @@ class Version(ndb.Model):
 
 class Content(ndb.Model):
   content = ndb.TextProperty(indexed=False)
+  content_compressed = ndb.BlobProperty(indexed=False)
 
   etag = ndb.StringProperty(indexed=False)
   status = ndb.StringProperty(default=Status.pending)
   error = ndb.StringProperty(indexed=False)
   updated = ndb.DateTimeProperty(auto_now=True)
+
+  def get_content(self):
+    if self.content_compressed:
+      return zlib.decompress(self.content_compressed)
+    return self.content
 
 class Dependency(object):
   def __init__(self, owner, repo, version):

--- a/src/manage.py
+++ b/src/manage.py
@@ -818,7 +818,7 @@ class IngestAnalysis(RequestHandler):
     if data == '':
       content.set_json(None)
     else:
-      content.set_json(data)
+      content.set_json(json.loads(data))
 
     if error is None:
       content.status = Status.ready

--- a/src/manage.py
+++ b/src/manage.py
@@ -13,7 +13,6 @@ import logging
 import os
 import urllib
 import webapp2
-import zlib
 
 from datamodel import Author, Status, Library, Version, Content, CollectionReference, Dependency, VersionCache, Sitemap
 import licenses
@@ -679,7 +678,7 @@ class IngestVersion(RequestHandler):
         bower_json = json.loads(response.content)
       except ValueError:
         return self.error("could not parse bower.json", ErrorCodes.Version_parse_bower)
-      Content(parent=self.version_key, id='bower', content=response.content,
+      Content(parent=self.version_key, id='bower', json=bower_json,
               status=Status.ready, etag=response.headers.get('ETag', None)).put()
       return bower_json
     elif response.status_code == 404:
@@ -692,7 +691,7 @@ class IngestVersion(RequestHandler):
     if bower is None:
       return
 
-    bower_json = json.loads(bower.get_content())
+    bower_json = bower.get_json()
 
     for _, path in bower_json.get('pages', {}).iteritems():
       response = util.github_get('repos', self.owner, self.repo, 'contents/' + path, params={'ref': self.sha})
@@ -728,7 +727,7 @@ class UpdateIndexes(RequestHandler):
 
     bower_key = ndb.Key(Library, Library.id(owner, repo), Version, version, Content, 'bower')
     bower_object = bower_key.get()
-    bower = {} if bower_object is None else json.loads(bower_object.content)
+    bower = {} if bower_object is None else bower_object.get_json()
     version_key = bower_key.parent()
     library = version_key.parent().get()
 
@@ -774,12 +773,12 @@ class UpdateIndexes(RequestHandler):
 
     analysis = Content.get_by_id('analysis', parent=version_key)
     if analysis is not None and analysis.status == Status.ready:
-      analysis = json.loads(analysis.get_content())
-      elements = analysis.get('elementsByTagName', {}).keys()
+      data = analysis.get_json()
+      elements = data.get('elementsByTagName', {}).keys()
       if elements != []:
         fields.append(search.TextField(name='element', value=' '.join(elements)))
         weights.append((' '.join(elements), 5))
-      behaviors = analysis.get('behaviorsByName', {}).keys()
+      behaviors = data.get('behaviorsByName', {}).keys()
       if behaviors != []:
         fields.append(search.TextField(name='behavior', value=' '.join(behaviors)))
         weights.append((' '.join(behaviors), 5))
@@ -814,18 +813,12 @@ class IngestAnalysis(RequestHandler):
     version_key = ndb.Key(Library, Library.id(owner, repo), Version, version)
 
     content = Content.get_by_id('analysis', parent=version_key)
-    compressed = zlib.compress(data)
     if content is None:
       return
     if data == '':
-      content.content = None
-      content.content_compressed = None
-    elif len(compressed) > 500000:
-      # Max entity size is only 1MB.
-      logging.error('content was too large: %d %s %s', len(compressed), Library.id(owner, repo), version)
-      error = 'content was too large: %d' % len(compressed)
+      content.set_json(None)
     else:
-      content.content_compressed = compressed
+      content.set_json(data)
 
     if error is None:
       content.status = Status.ready

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -95,7 +95,7 @@ class AnalyzeTest(ManageTestBase):
     self.assertEqual(response.status_int, 200)
 
     content = Content.get_by_id('analysis', parent=version_key)
-    self.assertEqual(content.get_content(), None)
+    self.assertEqual(content.get_json(), None)
     self.assertEqual(content.status, Status.pending)
 
     tasks = self.tasks.get_filtered_tasks()
@@ -108,7 +108,8 @@ class AnalyzeTest(ManageTestBase):
     version_key = Version(id='v1.1.1', parent=library_key, sha='sha', status='ready').put()
 
     content = Content(id='analysis', parent=version_key, status=Status.pending)
-    content.content = 'existing data'
+    data = {"data": "existing data"}
+    content.json = data
     content.status = Status.ready
     content.put()
 
@@ -116,7 +117,7 @@ class AnalyzeTest(ManageTestBase):
     self.assertEqual(response.status_int, 200)
 
     content = Content.get_by_id('analysis', parent=version_key)
-    self.assertEqual(content.get_content(), 'existing data')
+    self.assertEqual(content.get_json(), data)
     self.assertEqual(content.status, Status.ready)
 
     tasks = self.tasks.get_filtered_tasks()
@@ -153,7 +154,7 @@ class AnalyzeTest(ManageTestBase):
     self.assertEqual(response.status_int, 200)
 
     content = Content.get_by_id('analysis', parent=version_key)
-    self.assertEqual(content.get_content(), None)
+    self.assertEqual(content.get_json(), None)
     self.assertEqual(content.status, Status.pending)
 
     tasks = self.tasks.get_filtered_tasks()
@@ -565,7 +566,7 @@ class IngestLibraryTest(ManageTestBase):
     readme_html = ndb.Key(Library, 'org/repo', Version, 'v1.0.0', Content, 'readme.html').get()
     self.assertEqual(readme_html.content, '<html>README</html>')
     bower = ndb.Key(Library, 'org/repo', Version, 'v1.0.0', Content, 'bower').get()
-    self.assertEqual(bower.content, '{}')
+    self.assertEqual(bower.get_json(), {})
 
   def test_ingest_preview(self):
     self.respond_to_github('https://api.github.com/repos/org/repo', '{"owner":{"login":"org"},"name":"repo"}')

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -95,7 +95,7 @@ class AnalyzeTest(ManageTestBase):
     self.assertEqual(response.status_int, 200)
 
     content = Content.get_by_id('analysis', parent=version_key)
-    self.assertEqual(content.content, None)
+    self.assertEqual(content.get_content(), None)
     self.assertEqual(content.status, Status.pending)
 
     tasks = self.tasks.get_filtered_tasks()
@@ -116,7 +116,7 @@ class AnalyzeTest(ManageTestBase):
     self.assertEqual(response.status_int, 200)
 
     content = Content.get_by_id('analysis', parent=version_key)
-    self.assertEqual(content.content, 'existing data')
+    self.assertEqual(content.get_content(), 'existing data')
     self.assertEqual(content.status, Status.ready)
 
     tasks = self.tasks.get_filtered_tasks()
@@ -153,7 +153,7 @@ class AnalyzeTest(ManageTestBase):
     self.assertEqual(response.status_int, 200)
 
     content = Content.get_by_id('analysis', parent=version_key)
-    self.assertEqual(content.content, None)
+    self.assertEqual(content.get_content(), None)
     self.assertEqual(content.status, Status.pending)
 
     tasks = self.tasks.get_filtered_tasks()


### PR DESCRIPTION
Fixes #938 

This changes uses gzip encoding to compress data before storing it. For a 700kb analyzer blob, this can be reduced down to ~40kb. In one case, #938, this was > 1mb before hand and ~70kb with the compression.

This doesn't affect the client API since that already uses gzip encoding. Also note that the API only serves hydrolysis or analyzer data and not both.