### PR TITLE
New raw service in Node

### DIFF
--- a/manage.yaml
+++ b/manage.yaml
@@ -16,6 +16,7 @@ skip_files:
 - scripts
 - client
 - node_modules
+- raw
 
 handlers:
 - url: /.*

--- a/raw/inline-demo.html
+++ b/raw/inline-demo.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<style>
+  body {
+    margin: 0;
+    overflow: hidden;
+  }
+
+  body:before {
+    border: 2px solid #ededed;
+    border-left: none;
+    border-bottom: none;
+    position: absolute;
+    content: '';
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+  }
+
+  iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+    position: absolute;
+    top: 0;
+    opacity: 1;
+    transition: -webkit-filter 500ms, opacity 300ms;
+  }
+
+  iframe.grey {
+    -webkit-filter: grayscale(100%);
+    z-index: 1;
+  }
+
+  iframe.fade {
+    opacity: 0;
+  }
+</style>
+<div id="container"></div>
+<script>
+  window.addEventListener('message', receiveMessage, false);
+  var currentFrame;
+  var loadingFrame;
+  var sourceWindow;
+  var timeoutId;
+  var numberOfMeasures = 0;
+  var demoId;
+
+  function receiveMessage(event) {
+    if (!event || !event.data || event.data.id == undefined || !event.data.source)
+      return;
+
+    // Allow messaging back to original window.
+    sourceWindow = event.source;
+    demoId = event.data.id;
+
+    var container = document.getElementById('container');
+    if (currentFrame)
+      currentFrame.classList.add('grey');
+
+    if (loadingFrame) {
+      loadingFrame.onload = null;
+      container.removeChild(loadingFrame);
+    }
+
+    if (timeoutId)
+      clearTimeout(timeoutId);
+    numberOfMeasures = 0;
+
+    loadingFrame = document.createElement('iframe');
+    loadingFrame.setAttribute('role', 'none');
+    container.appendChild(loadingFrame);
+
+    loadingFrame.contentDocument.open();
+    loadingFrame.contentDocument.write('<!doctype html>');
+    loadingFrame.contentDocument.write(event.data.source);
+    loadingFrame.contentDocument.close();
+
+    if (loadingFrame.contentDocument.readyState == 'loading') {
+      loadingFrame.onload = iframeLoaded;
+    } else {
+      iframeLoaded();
+    }
+  }
+
+  function iframeLoaded() {
+    var oldFrame = currentFrame;
+    currentFrame = loadingFrame;
+    loadingFrame = null;
+
+    postHeight();
+
+    if (oldFrame) {
+      oldFrame.classList.add('fade');
+      setTimeout(removeFrame.bind(null, oldFrame), 500);
+    }
+  }
+
+  function removeFrame(frame) {
+    if (frame && frame.parentElement)
+      frame.parentElement.removeChild(frame);
+  }
+
+  function postHeight() {
+    if (sourceWindow && currentFrame && currentFrame.contentDocument)
+      sourceWindow.postMessage({id: demoId, height: currentFrame.contentDocument.documentElement.offsetHeight}, '*');
+    numberOfMeasures++;
+    timeoutId = setTimeout(postHeight, Math.min(1000, 100 * numberOfMeasures));
+  }
+</script>

--- a/raw/package.json
+++ b/raw/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "raw",
+  "private": true,
+  "engines": {
+    "node": ">7"
+  },
+  "scripts": {
+    "start": "node server.js",
+    "test": "ava -t --tap test.js | tap-dot"
+  },
+  "dependencies": {
+    "@google-cloud/datastore": "^1.0.0",
+    "@google/cloud-debug": "^0.9.2",
+    "@google/cloud-trace": "^0.6.3",
+    "express": "^4.15.2"
+  },
+  "devDependencies": {
+    "ava": "^0.19.1",
+    "proxyquire": "^1.7.11",
+    "sinon": "^2.1.0",
+    "supertest": "^3.0.0",
+    "tap-dot": "^1.0.5"
+  }
+}

--- a/raw/package.json
+++ b/raw/package.json
@@ -2,7 +2,7 @@
   "name": "raw",
   "private": true,
   "engines": {
-    "node": ">7"
+    "node": ">=7"
   },
   "scripts": {
     "start": "node server.js",
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@google-cloud/datastore": "^1.0.0",
-    "@google/cloud-debug": "^0.9.2",
-    "@google/cloud-trace": "^0.6.3",
+    "@google-cloud/debug-agent": "^1.0.0",
+    "@google-cloud/trace-agent": "^1.1.0",
     "express": "^4.15.2"
   },
   "devDependencies": {

--- a/raw/package.json
+++ b/raw/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "ava": "^0.19.1",
+    "nock": "^9.0.13",
     "proxyquire": "^1.7.11",
     "sinon": "^2.1.0",
     "supertest": "^3.0.0",

--- a/raw/raw.yaml
+++ b/raw/raw.yaml
@@ -1,3 +1,10 @@
 runtime: nodejs
 env: flex
 service: raw
+skip_files:
+- ^(.*/)?#.*#$
+- ^(.*/)?.*~$
+- ^(.*/)?.*\.py[co]$
+- ^(.*/)?.*/RCS/.*$
+- ^(.*/)?\..*$
+- node_modules

--- a/raw/raw.yaml
+++ b/raw/raw.yaml
@@ -1,0 +1,3 @@
+runtime: nodejs
+env: flex
+service: raw

--- a/raw/server.js
+++ b/raw/server.js
@@ -1,8 +1,8 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-  require('@google/cloud-trace').start();
-  require('@google/cloud-debug').start();
+  require('@google-cloud/debug-agent').start({allowExpressions: true});
+  require('@google-cloud/trace-agent').start();
 }
 
 const express = require('express');

--- a/raw/server.js
+++ b/raw/server.js
@@ -1,0 +1,56 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  require('@google/cloud-trace').start();
+  require('@google/cloud-debug').start();
+}
+
+const express = require('express');
+const datastore = require('@google-cloud/datastore')();
+const app = express();
+
+// Error on absolute path values.
+app.get('/:owner/:repo/:tag', (request, response) => {
+  response.set('Access-Control-Allow-Origin', '*');
+  response.status(400).send('Error: Invalid request. Try using a relative path if you are using an absolute path.');
+});
+
+// Redirect requests with incorrectly specified bower_components path.
+app.get('/:owner/:repo/:tag/:before([\\s\\S]*)/bower_components/:after([\\s\\S]*)', (req, response) => {
+  response.set('cache-control', 'max-age=315569000');
+  var url = [req.params.owner, req.params.repo, req.params.tag, req.params.after].join('/');
+  response.redirect(301, url);
+});
+
+app.get('/', async(request, response) => {
+  await datastore.get('null').catch((err) => { 
+    response.send(err);
+  });
+});
+
+app.get('/:owner/:repo/:tag/:name/:path([\\s\\S]*)', async (req, res) => {
+  var owner = req.params.owner.toLowerCase();
+  var repo = req.params.repo.toLowerCase();
+  var path = req.params.path;
+  if (path.endsWith('/'))
+    path = path + 'index.html';
+  var key = datastore.key(['Library', owner + '/' + repo, 'Version', req.params.tag, 'Content', 'analysis']);
+
+  var analysis = await datastore.get(key);
+
+  if (!analysis.length || analysis[0] == undefined) {
+    res.status(404).send(`Could not find analysis content for ${req.params.tag} in ${owner}/${repo}`);
+    return;
+  }
+
+  res.sendStatus(200);
+});
+
+if (module === require.main) {
+  const server = app.listen(process.env.PORT || 8081, () => {
+    const port = server.address().port;
+    console.log(`App listening on port ${port}`);
+  });
+}
+
+module.exports = app;

--- a/raw/server.js
+++ b/raw/server.js
@@ -7,6 +7,7 @@ if (process.env.NODE_ENV === 'production') {
 
 const express = require('express');
 const datastore = require('@google-cloud/datastore')();
+const https = require('https');
 const app = express();
 
 // Error on absolute path values.
@@ -22,15 +23,10 @@ app.get('/:owner/:repo/:tag/:before([\\s\\S]*)/bower_components/:after([\\s\\S]*
   response.redirect(301, url);
 });
 
-app.get('/', async(request, response) => {
-  await datastore.get('null').catch((err) => { 
-    response.send(err);
-  });
-});
-
-app.get('/:owner/:repo/:tag/:name/:path([\\s\\S]*)', async (req, res) => {
+app.get('/:owner/:repo/:tag/:name:path(/[\\s\\S]*)', async (req, res) => {
   var owner = req.params.owner.toLowerCase();
   var repo = req.params.repo.toLowerCase();
+  var tag = req.params.tag;
   var path = req.params.path;
   if (path.endsWith('/'))
     path = path + 'index.html';
@@ -38,12 +34,67 @@ app.get('/:owner/:repo/:tag/:name/:path([\\s\\S]*)', async (req, res) => {
 
   var analysis = await datastore.get(key);
 
-  if (!analysis.length || analysis[0] == undefined) {
-    res.status(404).send(`Could not find analysis content for ${req.params.tag} in ${owner}/${repo}`);
+  if (!analysis.length || analysis[0] == undefined || analysis[0].status != 'ready') {
+    res.status(404).send(`Could not find analysis content for ${tag} in ${owner}/${repo}`);
     return;
   }
 
-  res.sendStatus(200);
+  var content = analysis[0].json;
+  if (!content && analysis[0].content)
+    content = JSON.parse(analysis[0].content);
+
+  if (!content || !content['bowerDependencies']) {
+    res.status(404).send(`Could not find dependencies for ${tag} in ${owner}/${repo}`);
+    return;
+  }
+
+  // Build a map of the repo's dependencies.
+  var dependencies = content['bowerDependencies'];
+  var configMap = new Map();
+  dependencies.forEach(x => {
+    if (x.owner != owner || x.repo != repo)
+      configMap.set(x.name, `${x.owner}/${x.repo}/${x.version}`);
+  });
+
+  // Ensure the repo serves its own version.
+  configMap.set(repo, `${owner}/${repo}/${tag}`);
+
+  if (!configMap.has(req.params.name)) {
+    res.status(400).send(`${req.params.name} is not a valid dependency for ${tag} in ${owner}/${repo}`);
+    return;
+  }
+
+  // Fetch resource from rawgit
+  const options = {
+    hostname: 'cdn.rawgit.com',
+    path: configMap.get(req.params.name) + path,
+    rejectUnauthorized: true,
+  }
+
+  https.get(options, (result) => {
+    if (result.statusCode != 200) {
+      res.status(400).send(`Invalid response from rawgit. Received ${result.statusCode} for ${options.hostname}/${options.path}.`);
+      return;
+    }
+
+    res.set({
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': result.headers['content-type'],
+      'Cache-Control': result.headers['cache-control'] || 'max-age=315569000'
+    });
+
+    result.setEncoding('utf8');
+    result.on('data', (d) => {
+      res.write(d);
+    });
+
+    result.on('end', (e) => {
+      res.end();
+    });
+
+  }).on('error', (e) => {
+    res.status(400).send(`Error fetching from rawgit. Attempted to fetch ${options.hostname}/${options.path}.`);
+  });
 });
 
 if (module === require.main) {

--- a/raw/server.js
+++ b/raw/server.js
@@ -78,7 +78,7 @@ app.get('/:owner/:repo/:tag/:name:path(/[\\s\\S]*)', async (req, res) => {
   const options = {
     hostname: 'cdn.rawgit.com',
     path: '/' + configMap.get(req.params.name) + path,
-  }
+  };
 
   https.get(options, (result) => {
     if (result.statusCode != 200) {

--- a/raw/test.js
+++ b/raw/test.js
@@ -57,7 +57,7 @@ test.cb('bower_components should redirect paths', (t) => {
 
 test.cb('acts sanely', (t) => {
   var scope = nock('https://cdn.rawgit.com')
-    .get('depOwner/depRepo/v2.0.0/parent/file.html')
+    .get('/depOwner/depRepo/v2.0.0/parent/file.html')
     .reply(200, 'my resource');
 
   request.get('/owner/repo/tag/depRepo/parent/file.html')
@@ -79,5 +79,11 @@ test.cb('analysis doesnt exist', (t) => {
 test.cb('throws invalid dependency', (t) => {
   request.get('/owner/repo/tag/nodep/blah/file.html')
     .expect(400)
+    .end(t.end);
+});
+
+test.cb('fetches inline demos', (t) => {
+  request.get('/owner/repo/tag/repo/')
+    .expect(200)
     .end(t.end);
 });

--- a/raw/test.js
+++ b/raw/test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const test = require('ava');
+const proxyquire = require('proxyquire').noCallThru();
+
+const datastoreStub = function() {
+  return {
+    key: function(params) {
+      if (params.includes('notexist'))
+        return 'notexist';
+      return '';
+    },
+
+    get: function(key) {
+      if (key == 'notexist')
+        return Promise.resolve([undefined]);
+      var data = {
+        "bowerDependencies": [
+          {
+            "owner": "owner",
+            "repo": "repo",
+            "version": "v1.0.0",
+            "name": "repo"
+          },
+          {
+            "owner": "depOwner",
+            "repo": "depRepo",
+            "version": "v2.0.0",
+            "name": "depRepo"
+          }
+        ]
+      };
+      return Promise.resolve([{content: JSON.stringify(data)}]);
+    }
+  }
+};
+
+const server = proxyquire('./server', { '@google-cloud/datastore': datastoreStub });
+const request = require('supertest')(server);
+
+test.cb('absolute paths result in error', (t) => {
+  request.get('/owner/repo/tag')
+    .expect(400)
+    .expect((response) => {
+      t.regex(response.text, /Error/);
+    })
+    .end(t.end);
+});
+
+test.cb('bower_components should redirect paths', (t) => {
+  request.get('/owner/repo/tag/my/path/bower_components/my/real/path.html')
+    .expect('Location', 'owner/repo/tag/my/real/path.html')
+    .expect(301)
+    .end(t.end);
+});
+
+test.cb('acts sanely', (t) => {
+  request.get('/owner/repo/tag/depRepo/parent/file.html')
+    .expect(200)
+    .end(t.end);
+});
+
+test.cb('analysis doesnt exist', (t) => {
+  request.get('/this/does/notexist/depRepo/parent/file.html')
+    .expect(404)
+    .end(t.end);
+});

--- a/raw/test.js
+++ b/raw/test.js
@@ -16,46 +16,46 @@ const datastoreStub = function() {
       if (key == 'notexist')
         return Promise.resolve([undefined]);
       var data = {
-        "bowerDependencies": [
+        bowerDependencies: [
           {
-            "owner": "owner",
-            "repo": "repo",
-            "version": "v1.0.0",
-            "name": "repo"
+            owner: "owner",
+            repo: "repo",
+            version: "v1.0.0",
+            name: "repo"
           },
           {
-            "owner": "depOwner",
-            "repo": "depRepo",
-            "version": "v2.0.0",
-            "name": "depRepo"
+            owner: "depOwner",
+            repo: "depRepo",
+            version: "v2.0.0",
+            name: "depRepo"
           }
         ]
       };
       return Promise.resolve([{content: JSON.stringify(data), status: 'ready'}]);
     }
-  }
+  };
 };
 
-const server = proxyquire('./server', { '@google-cloud/datastore': datastoreStub });
+const server = proxyquire('./server', {'@google-cloud/datastore': datastoreStub});
 const request = require('supertest')(server);
 
-test.cb('absolute paths result in error', (t) => {
+test.cb('absolute paths result in error', t => {
   request.get('/owner/repo/tag')
     .expect(400)
-    .expect((response) => {
+    .expect(response => {
       t.regex(response.text, /Error/);
     })
     .end(t.end);
 });
 
-test.cb('bower_components should redirect paths', (t) => {
+test.cb('bower_components should redirect paths', t => {
   request.get('/owner/repo/tag/my/path/bower_components/my/real/path.html')
     .expect('Location', 'owner/repo/tag/my/real/path.html')
     .expect(301)
     .end(t.end);
 });
 
-test.cb('acts sanely', (t) => {
+test.cb('acts sanely', t => {
   var scope = nock('https://cdn.rawgit.com')
     .get('/depOwner/depRepo/v2.0.0/parent/file.html')
     .reply(200, 'my resource');
@@ -70,19 +70,19 @@ test.cb('acts sanely', (t) => {
     .end(t.end);
 });
 
-test.cb('analysis doesnt exist', (t) => {
+test.cb('analysis doesnt exist', t => {
   request.get('/this/does/notexist/depRepo/parent/file.html')
     .expect(404)
     .end(t.end);
 });
 
-test.cb('throws invalid dependency', (t) => {
+test.cb('throws invalid dependency', t => {
   request.get('/owner/repo/tag/nodep/blah/file.html')
     .expect(400)
     .end(t.end);
 });
 
-test.cb('fetches inline demos', (t) => {
+test.cb('fetches inline demos', t => {
   request.get('/owner/repo/tag/repo/')
     .expect(200)
     .end(t.end);

--- a/redirect.yaml
+++ b/redirect.yaml
@@ -16,6 +16,7 @@ skip_files:
 - scripts
 - client
 - node_modules
+- raw
 
 handlers:
 - url: /service-worker.js

--- a/user-content.yaml
+++ b/user-content.yaml
@@ -16,6 +16,7 @@ skip_files:
 - scripts
 - client
 - node_modules
+- raw
 
 handlers:
 - url: /[^/]+/[^/]+/[^/]+/[^/]+/


### PR DESCRIPTION
Part of #954.

This duplicates behavior in the user content service into a new 'raw' service. This will allow us to import modules to easily support on the fly transpilation. This service is currently identical to user content with the addition of tests (!).

[Design document](https://docs.google.com/a/google.com/document/d/1sIpX29rR6UQmXtId4tQSk_c_8mbaV9qrmXQmWCUUteE/edit?usp=sharing) for transpilation.


