### PR TITLE
Transpilation on request for raw service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,15 @@ env:
   - secure: hwsxx5wg82V14R7A1qX6C/EOVZl/bC91sxtcj7pODHqw8WIG5ECzms4QLkpFS+e7pEZqQ5fiF9A9AWidtXaowu/wrGMGhRrB4ZsUvnmeoql9YcKpmm9HnUY7Ers8aC2g2wbNKg7zpOqytQHt8MDtXtCmLibapMU/CMKMhvoFWF/eNcVa6RwqGvtx1NAWyLZP2rnSVYyxxupUABssRqk8zMf/Fp+RGa2tuRQajyXhI6Zj2f3+FTpzzvHtEiFLHNhPq06/BaDPzkgDuXg1J+qIUfUA42FZWUFfDJ0MSDQBai/d9oyKZO8oqfydAU4WljfjP7c26b0/5kErEwoWASJWc6/O10G8LW+7k2FiAKkGvX7LcTylATBPWkaYyxynTef/m8L8PYwLk5ENXsb1nJGxcDLLW03eHfw3LyMl5rbD83HQH+WQAZAmuQpJvJqPo+GGU2EpXWOJFgI3AM4uD6zU7B69qdMwcUwUSGq0mIf2CPeHdgw00cMoVJIK+ziedVXiBADyBpAx106mhOUxH6wCMhEmrosnA8t/TNm4B4OI0NhD+TbFCYkOX04CtJJhBuZy9izF+rIWUeORO4l3+vqX+q6kt1se/Tcp3L6FoQoraG+pFzngU4e3birx/VRfdaaC6eLebyJNw+EErGutq7/40GnEC84l8xmlXZZ4UmPWddU=
   - secure: MjIX930aIdFU4Hu25tsjzhH+n+7zpA3A03PGAtrSDKZJOkh8v4uHwxsI3iFoPTW9XGPmqqUZ8KS/0JVMr3Lu7bdaR9nRjjxQq6lwM1OBwRUazjD5YgAM8cvHIQdFrMkrTdfZrasR8dJnDp1bvMfwnmV6FZsnElbqt9JHoBS1qrggvCkfWToxw2ZgQ5EKwR7pxR4yYd+7DXmGGzrxUQhyk+jiGC+scG0yZnIM58TiN1UN9PmJlESkFfgLh/kgvKo2krmTf6aPWmjaO4lgfpirkhPEtmQoe6M4IgrTSW5Iv01nnfpTWAFzzXKNTkDwvmylW3quUR/a/zhVkeoQD+HyvnGzoH1OWugLGq/VCDFLRgnIbwKLD5abuAAz3cnuwRh8E3ZclVhT+RSU4wteznu46Ksd8jnXGPseIXoTXWHQWeQ/PbPgDYGi5PbZib4+KnNLHdCmF8lQg+nFMaz1mMnx2fPz/rM2fwi4wTyi/M4xtb6VpYtxV6ChdvH8Qa5VB05EwpI+FVLWTGntssf0HwoDdLzmiQnxvxQfCnjST/CFa0gKkp86r3UpIgteaekrb51X9gvz0jJbo1vVsixgEla+0K6xZwYwCLozFTx02s40E8bB2tt2qmaDfxO1ivYjhgKK4NIBDugrOIJ5dLJHq0i4hyKye0HMnA0EyLB0DV0YfVA=
 before_install:
-- nvm install 6
-- nvm use 6
+- nvm install 7
+- nvm use 7
 - mkdir -p lib
 install:
 - npm install
 - npm install -g bower
 - "(cd client; npm install)"
 - "(cd analysis; npm install)"
+- "(cd raw; npm install)"
 - pip install -r requirements.txt -t lib/
 - if [ ! -d $HOME/gcloud/google-cloud-sdk ]; then mkdir -p $HOME/gcloud && wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz
   --directory-prefix=$HOME/gcloud && cd $HOME/gcloud && tar xzf google-cloud-sdk.tar.gz
@@ -43,6 +44,7 @@ script:
 - python tests.py $HOME/gcloud/google-cloud-sdk
 - "(cd client; xvfb-run npm test)"
 - "(cd analysis; npm test)"
+- "(cd raw; npm test)"
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then (cd client; npm run test-sauce); fi
 before_deploy:
 - openssl aes-256-cbc -K $encrypted_ab98d8519375_key -iv $encrypted_ab98d8519375_iv

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ cache:
     - gcloud
     - analysis/node_modules
     - $HOME/.yarn-cache
+    - raw/node_modules
 env:
   global:
   - secure: hwsxx5wg82V14R7A1qX6C/EOVZl/bC91sxtcj7pODHqw8WIG5ECzms4QLkpFS+e7pEZqQ5fiF9A9AWidtXaowu/wrGMGhRrB4ZsUvnmeoql9YcKpmm9HnUY7Ers8aC2g2wbNKg7zpOqytQHt8MDtXtCmLibapMU/CMKMhvoFWF/eNcVa6RwqGvtx1NAWyLZP2rnSVYyxxupUABssRqk8zMf/Fp+RGa2tuRQajyXhI6Zj2f3+FTpzzvHtEiFLHNhPq06/BaDPzkgDuXg1J+qIUfUA42FZWUFfDJ0MSDQBai/d9oyKZO8oqfydAU4WljfjP7c26b0/5kErEwoWASJWc6/O10G8LW+7k2FiAKkGvX7LcTylATBPWkaYyxynTef/m8L8PYwLk5ENXsb1nJGxcDLLW03eHfw3LyMl5rbD83HQH+WQAZAmuQpJvJqPo+GGU2EpXWOJFgI3AM4uD6zU7B69qdMwcUwUSGq0mIf2CPeHdgw00cMoVJIK+ziedVXiBADyBpAx106mhOUxH6wCMhEmrosnA8t/TNm4B4OI0NhD+TbFCYkOX04CtJJhBuZy9izF+rIWUeORO4l3+vqX+q6kt1se/Tcp3L6FoQoraG+pFzngU4e3birx/VRfdaaC6eLebyJNw+EErGutq7/40GnEC84l8xmlXZZ4UmPWddU=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ At a high-level, the services are:
 - Analysis, a node.js service that performs slower analysis on ingested elements, using Bower and Hydrolysis.
 
 ## Additional documentation for client & analysis services
-For more detailed guides refer to [client](client) & [analysis](analysis).
+For more detailed guides refer to [client](client), [analysis](analysis) & [raw](raw).
 
 ## System-level dependencies
 The following dependencies are required to develop, test and/or deploy www.webcomponents.org:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
     },
 
     eslint: {
-      target: ['client/src/**/*.html', 'analysis/*.js']
+      target: ['client/src/**/*.html', 'analysis/*.js', 'raw/*.js']
     },
   });
   grunt.loadNpmTasks('grunt-pylint');

--- a/analysis/package.json
+++ b/analysis/package.json
@@ -13,7 +13,6 @@
     "hydrolysis": "1.25.0",
     "lockfile": "1.0.1",
     "polymer-analyzer": "2.0.0-alpha.42",
-    "polyserve": "^0.19.0",
     "stream-buffers": "3.0.1"
   },
   "engines": {

--- a/analysis/package.json
+++ b/analysis/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.1",
   "private": true,
   "dependencies": {
-    "@google/cloud-debug": "0.8.4",
     "@google-cloud/pubsub": "0.1.1",
+    "@google/cloud-debug": "0.8.4",
     "@google/cloud-trace": "0.5.7",
     "body-parser": "1.14.2",
     "bower": "1.7.9",
@@ -13,6 +13,7 @@
     "hydrolysis": "1.25.0",
     "lockfile": "1.0.1",
     "polymer-analyzer": "2.0.0-alpha.42",
+    "polyserve": "^0.19.0",
     "stream-buffers": "3.0.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "eslintConfig": {
     "extends": "google",
     "env": {
-      "browser": true
+      "browser": true,
+      "node": true
     },
     "plugins": [
       "html"
@@ -44,6 +45,10 @@
       "eqeqeq": 0,
       "no-eq-null": 0,
       "require-jsdoc": 0
+    },
+    "parserOptions": {
+      "ecmaVersion": 8,
+      "sourceType": "module"
     }
   }
 }

--- a/raw/README.md
+++ b/raw/README.md
@@ -1,0 +1,15 @@
+# Raw service
+This is a Google App Engine Node.js service which serves content from GitHub repos inside versioned web components
+published on webcomponents.org.
+
+## Installing
+This service requires Node 7+.
+
+```bash
+npm install
+```
+
+## Testing
+```bash
+npm test
+```

--- a/raw/package.json
+++ b/raw/package.json
@@ -12,7 +12,8 @@
     "@google-cloud/datastore": "^1.0.0",
     "@google-cloud/debug-agent": "^1.0.0",
     "@google-cloud/trace-agent": "^1.1.0",
-    "express": "^4.15.2"
+    "express": "^4.15.2",
+    "polyserve": "^0.19.0"
   },
   "devDependencies": {
     "ava": "^0.19.1",

--- a/raw/resources/class-element.html
+++ b/raw/resources/class-element.html
@@ -1,0 +1,14 @@
+<link rel="import"  href="https://polygit.org/polymer+2.0.0-rc.2/components/polymer/polymer-element.html">
+
+<script>
+  // Define the class for a new element called custom-element
+  class CustomElement extends Polymer.Element {
+    static get is() { return "custom-element"; }
+    constructor() {
+        super();
+        this.textContent = "I'm a custom-element.";
+      }
+  }
+  // Register the new element with the browser
+  customElements.define(CustomElement.is, CustomElement);
+</script>

--- a/raw/server.js
+++ b/raw/server.js
@@ -29,13 +29,13 @@ app.get(optionalTranspile('/:owner/:repo/:tag'), (request, response) => {
 });
 
 // Redirect requests with incorrectly specified bower_components path.
-app.get('/:owner/:repo/:tag/:before([\\s\\S]*)/bower_components/:after([\\s\\S]*)', (req, response) => {
+app.get(optionalTranspile('/:owner/:repo/:tag/:before([\\s\\S]*)/bower_components/:after([\\s\\S]*)'), (req, response) => {
   response.set('cache-control', 'max-age=315569000');
   var url = [req.params.owner, req.params.repo, req.params.tag, req.params.after].join('/');
   response.redirect(301, url);
 });
 
-app.get('/[^/]+/[^/]+/[^/]+/[^/]+/', (request, response) => {
+app.get(optionalTranspile('/[^/]+/[^/]+/[^/]+/[^/]+/'), (request, response) => {
   response.sendFile(__dirname + '/inline-demo.html');
 });
 

--- a/raw/server.js
+++ b/raw/server.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
@@ -31,47 +32,47 @@ app.get(optionalTranspile('/:owner/:repo/:tag'), (request, response) => {
 // Redirect requests with incorrectly specified bower_components path.
 app.get(optionalTranspile('/:owner/:repo/:tag/:before([\\s\\S]*)/bower_components/:after([\\s\\S]*)'), (req, response) => {
   response.set('cache-control', 'max-age=315569000');
-  var url = [req.params.owner, req.params.repo, req.params.tag, req.params.after].join('/');
+  const url = [req.params.owner, req.params.repo, req.params.tag, req.params.after].join('/');
   response.redirect(301, url);
 });
 
 app.get(optionalTranspile('/[^/]+/[^/]+/[^/]+/[^/]+/'), (request, response) => {
-  response.sendFile(__dirname + '/inline-demo.html');
+  response.sendFile(path.resolve(__dirname, 'inline-demo.html'));
 });
 
 app.get(optionalTranspile('/:owner/:repo/:tag/:name:path(/[\\s\\S]*)'), async (req, res) => {
-  var owner = req.params.owner.toLowerCase();
-  var repo = req.params.repo.toLowerCase();
-  var tag = req.params.tag;
-  var path = req.params.path;
+  const owner = req.params.owner.toLowerCase();
+  const repo = req.params.repo.toLowerCase();
+  const tag = req.params.tag;
+  let path = req.params.path;
   if (path.endsWith('/'))
-    path = path + 'index.html';
-  var key = datastore.key(['Library', owner + '/' + repo, 'Version', req.params.tag, 'Content', 'analysis']);
+    path += 'index.html';
+  const key = datastore.key(['Library', owner + '/' + repo, 'Version', req.params.tag, 'Content', 'analysis']);
 
-  var analysis = await datastore.get(key);
+  const analysis = await datastore.get(key);
 
   if (!analysis.length || analysis[0] == undefined || analysis[0].status != 'ready') {
     res.status(404).send(`Could not find analysis content for ${tag} in ${owner}/${repo}`);
     return;
   }
 
-  var content = null;
+  let content = null;
   if (analysis[0].json) {
     // Decompress and parse.
-    var decompressed = zlib.unzipSync(analysis[0].json);
+    const decompressed = zlib.unzipSync(analysis[0].json);
     content = JSON.parse(decompressed.toString());
   } else if (analysis[0].content) {
     content = JSON.parse(analysis[0].content);
   }
 
-  if (!content || !content['bowerDependencies']) {
+  if (!content || !content.bowerDependencies) {
     res.status(404).send(`Could not find dependencies for ${tag} in ${owner}/${repo}`);
     return;
   }
 
   // Build a map of the repo's dependencies.
-  var dependencies = content['bowerDependencies'];
-  var configMap = new Map();
+  const dependencies = content.bowerDependencies;
+  const configMap = new Map();
   dependencies.forEach(x => {
     if (x.owner != owner || x.repo != repo)
       configMap.set(x.name, `${x.owner}/${x.repo}/${x.version}`);
@@ -91,7 +92,7 @@ app.get(optionalTranspile('/:owner/:repo/:tag/:name:path(/[\\s\\S]*)'), async (r
     path: '/' + configMap.get(req.params.name) + path,
   };
 
-  https.get(options, (result) => {
+  https.get(options, result => {
     if (result.statusCode != 200) {
       res.status(400).send(`Invalid response from rawgit. Received ${result.statusCode} for ${options.hostname}/${options.path}.`);
       return;
@@ -104,15 +105,14 @@ app.get(optionalTranspile('/:owner/:repo/:tag/:name:path(/[\\s\\S]*)'), async (r
     });
 
     result.setEncoding('utf8');
-    result.on('data', (d) => {
+    result.on('data', d => {
       res.write(d);
     });
 
-    result.on('end', (e) => {
+    result.on('end', () => {
       res.end();
     });
-
-  }).on('error', (e) => {
+  }).on('error', () => {
     res.status(400).send(`Error fetching from rawgit. Attempted to fetch ${options.hostname}/${options.path}.`);
   });
 });

--- a/raw/test.js
+++ b/raw/test.js
@@ -49,8 +49,24 @@ test.cb('absolute paths result in error', t => {
     .end(t.end);
 });
 
+test.cb('absolute paths result in error - transpiled', t => {
+  request.get('/transpile/owner/repo/tag')
+    .expect(400)
+    .expect(response => {
+      t.regex(response.text, /Error/);
+    })
+    .end(t.end);
+});
+
 test.cb('bower_components should redirect paths', t => {
   request.get('/owner/repo/tag/my/path/bower_components/my/real/path.html')
+    .expect('Location', 'owner/repo/tag/my/real/path.html')
+    .expect(301)
+    .end(t.end);
+});
+
+test.cb('bower_components should redirect paths - transpiled', t => {
+  request.get('/transpile/owner/repo/tag/my/path/bower_components/my/real/path.html')
     .expect('Location', 'owner/repo/tag/my/real/path.html')
     .expect(301)
     .end(t.end);
@@ -85,6 +101,12 @@ test.cb('throws invalid dependency', t => {
 
 test.cb('fetches inline demos', t => {
   request.get('/owner/repo/tag/repo/')
+    .expect(200)
+    .end(t.end);
+});
+
+test.cb('fetches inline demos - transpiled', t => {
+  request.get('/transpile/owner/repo/tag/repo/')
     .expect(200)
     .end(t.end);
 });

--- a/raw/test.js
+++ b/raw/test.js
@@ -140,7 +140,7 @@ test.cb('transpiles when requested', t => {
   request.get('/transpile/owner/repo/tag/depRepo/parent/file.html')
     .expect(200)
     .expect('Access-Control-Allow-Origin', '*')
-    .expect((response) => {
+    .expect(response => {
       if (response.text == classElement) {
         throw new Error('Did not transpile result');
       }


### PR DESCRIPTION
Part of #954.

This change uses the transpilation middleware used in polyserve to a) transpile and b) inject the `custom-elements-es5-adapter` which allows native class-style custom elements to be used after it has been transpiled to es5.

Requests to `raw` are unchanged and transpilation is only when the request is only transformed when the request is prefixed with `/transpile`.

The final piece of the puzzle is to add client side decisions on when to transpile. This can be UA-based determination and/or explicit toggles.

