### PR TITLE
Remove cyclical object from bower conflict error

### DIFF
--- a/analysis/src/main.js
+++ b/analysis/src/main.js
@@ -96,6 +96,8 @@ function processTasks() {
           Ana.fail("main/processTasks");
           attributes.error = "true";
           error.consoleOutput = Ana.readBuffer();
+          if (error.error)
+            delete error.error.picks;
           catalog.postResponse(error, attributes)
               .then(() => res.sendStatus(200))
               .catch(() => res.sendStatus(500));


### PR DESCRIPTION
In some cases a conflict error is thrown but the task never completes. This is due to a large cyclical object in bower's error. Removing it allows it to fail as expected (currently these task are still outstanding).