### PR TITLE
Follow redirects and don't set encoding of rawgit responses

### DIFF
--- a/raw/package.json
+++ b/raw/package.json
@@ -13,7 +13,8 @@
     "@google-cloud/debug-agent": "^1.0.0",
     "@google-cloud/trace-agent": "^1.1.0",
     "express": "^4.15.2",
-    "polyserve": "^0.19.0"
+    "polyserve": "^0.19.0",
+    "request": "^2.81.0"
   },
   "devDependencies": {
     "ava": "^0.19.1",

--- a/raw/server.js
+++ b/raw/server.js
@@ -108,7 +108,7 @@ app.get(optionalTranspile('/:owner/:repo/:tag/:name:path(/[\\s\\S]*)'), async (r
       res.end();
     });
   }).on('error', () => {
-    res.status(400).send(`Error fetching from rawgit. Attempted to fetch ${options.hostname}/${options.path}.`);
+    res.status(400).send(`Error fetching from rawgit. Attempted to fetch ${url}.`);
   });
 });
 


### PR DESCRIPTION
Fixes #966.

Permanent redirects from rawgit were not being followed and were hence throwing errors. After this was corrected, the byte stream was always interpreted as utf8, which isn't the case for images.