### PR TITLE
Fix inherited properties in analysis

### DIFF
--- a/analysis/package.json
+++ b/analysis/package.json
@@ -12,7 +12,7 @@
     "express": "4.13.4",
     "hydrolysis": "1.25.0",
     "lockfile": "1.0.1",
-    "polymer-analyzer": "2.0.0-alpha.42",
+    "polymer-analyzer": "^2.0.1",
     "stream-buffers": "3.0.1"
   },
   "engines": {

--- a/analysis/src/analysis.js
+++ b/analysis/src/analysis.js
@@ -51,7 +51,7 @@ class Analysis {
           reject({retry: false, erorr: Error("Installed package not found")});
           return;
         }
-        var absolutePaths = result.mainHtmls.map(x => path.resolve(result.root, x));
+
         return Promise.all([
           this.analyzer.analyze(result.root, result.mainHtmls),
           this.bower.findDependencies(attributes.owner, attributes.repo, versionOrSha)]);

--- a/analysis/src/analyzer.js
+++ b/analysis/src/analyzer.js
@@ -2,33 +2,33 @@
 
 const Ana = require('./ana_log');
 
-const Analyzer = require('polymer-analyzer').Analyzer;
-const Analysis = require('polymer-analyzer/lib/analysis-format');
-const generateAnalysis = require('polymer-analyzer/lib/generate-analysis').generateAnalysis;
-const Feature = require('polymer-analyzer/lib/model/model');
+const {Analyzer, generateAnalysis} = require('polymer-analyzer');
 const FSUrlLoader = require('polymer-analyzer/lib/url-loader/fs-url-loader').FSUrlLoader;
 const PackageUrlResolver = require('polymer-analyzer/lib/url-loader/package-url-resolver').PackageUrlResolver;
+const path = require('path');
 
 class AnalyzerRunner {
   analyze(root, inputs) {
     return new Promise((resolve, reject) => {
       Ana.log('analyzer/analyze', inputs);
 
+      // Move up a directory so analyzer will look at all dependencies properly.
+      var analyzerRoot = path.dirname(root);
+      var paths = inputs.map(x => path.join(path.basename(root), x));
+
       const analyzer = new Analyzer({
-        urlLoader: new FSUrlLoader(root),
+        urlLoader: new FSUrlLoader(analyzerRoot),
         urlResolver: new PackageUrlResolver(),
       });
 
-      const isInTests = /(\b|\/|\\)(test)(\/|\\)/;
-      const isNotTest = feature =>
-          feature.sourceRange != null && !isInTests.test(feature.sourceRange.file);
+      const isInPackage = feature => feature.sourceRange != null && feature.sourceRange.file.startsWith(path.basename(root));
 
       if (inputs == null || inputs.length === 0) {
         resolve({});
         // TODO: fall back to package analysis
       } else {
-        analyzer.analyze(inputs).then(function(analysis) {
-          resolve(generateAnalysis(analysis, root));
+        analyzer.analyze(paths).then(function(analysis) {
+          resolve(generateAnalysis(analysis, root, isInPackage));
         }).catch(function(error) {
           Ana.fail('analyzer/analyze', inputs, error);
           reject({retry: true, error: error});


### PR DESCRIPTION
Fixes #972.

Root cause of the issue is that the property is inherited from a dependency. Currently the package is installed via bower and hence dependencies are siblings of that repository. Analyzer ignored these sibling dependencies. This change rolls analyzer and moves the analyzed directory to all `bower_components` with the same main HTML paths. The resulting analysis is then filtered by the installed package.