### PR TITLE
Support package publishing

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -632,9 +632,14 @@ class PublishLibrary(webapp2.RequestHandler):
     if len(split) is 2:
       scope = split[0]
       package = split[1]
-    else:
+    elif len(split) is 1:
       scope = '@@npm'
       package = library
+    else:
+      self.response.set_status(400)
+      self.response.write('Invalid name')
+      return
+
     # TODO: validate valid repo and return result
     task_url = util.ingest_library_task(scope, package)
     util.new_task(task_url, target='manage')

--- a/src/api.py
+++ b/src/api.py
@@ -624,11 +624,19 @@ class PreviewCommit(webapp2.RequestHandler):
     self.response.write('%s/%s/%s' % (owner, repo, sha))
 
 class PublishLibrary(webapp2.RequestHandler):
-  def post(self, owner, repo):
+  def post(self, library):
     if not validate_captcha(self):
       return
+
+    split = library.split('/')
+    if len(split) is 2:
+      scope = split[0]
+      package = split[1]
+    else:
+      scope = '@@npm'
+      package = library
     # TODO: validate valid repo and return result
-    task_url = util.ingest_library_task(owner, repo)
+    task_url = util.ingest_library_task(scope, package)
     util.new_task(task_url, target='manage')
 
 class GetSitemap(webapp2.RequestHandler):
@@ -656,7 +664,7 @@ class GetSitemap(webapp2.RequestHandler):
 
 # pylint: disable=invalid-name
 app = webapp2.WSGIApplication([
-    webapp2.Route(r'/api/publish/<owner>/<repo>', handler=PublishLibrary),
+    webapp2.Route(r'/api/publish/<library:([^\/]+|@?[^\/]+\/[^\/]+)>', handler=PublishLibrary),
     webapp2.Route(r'/api/preview', handler=RegisterPreview),
     webapp2.Route(r'/api/preview-event', handler=PreviewEvent),
     webapp2.Route(r'/api/preview-commit', handler=PreviewCommit),

--- a/src/api_test.py
+++ b/src/api_test.py
@@ -13,6 +13,37 @@ class ApiTestBase(TestBase):
     TestBase.setUp(self)
     self.app = webtest.TestApp(app)
 
+class PublishTest(ApiTestBase):
+  def test_add(self):
+    self.respond_to('https://www.google.com/recaptcha/api/siteverify', '{"success": true}')
+
+    response = self.app.post('/api/publish/owner/repo')
+    self.assertEqual(response.status_int, 200)
+
+    tasks = self.tasks.get_filtered_tasks()
+    self.assertEqual(len(tasks), 1)
+    self.assertEqual(tasks[0].url, util.ingest_library_task('owner', 'repo'))
+
+  def test_add_scope(self):
+    self.respond_to('https://www.google.com/recaptcha/api/siteverify', '{"success": true}')
+
+    response = self.app.post('/api/publish/@scope/package')
+    self.assertEqual(response.status_int, 200)
+
+    tasks = self.tasks.get_filtered_tasks()
+    self.assertEqual(len(tasks), 1)
+    self.assertEqual(tasks[0].url, util.ingest_library_task('@scope', 'package'))
+
+  def test_add_no_scope(self):
+    self.respond_to('https://www.google.com/recaptcha/api/siteverify', '{"success": true}')
+
+    response = self.app.post('/api/publish/package')
+    self.assertEqual(response.status_int, 200)
+
+    tasks = self.tasks.get_filtered_tasks()
+    self.assertEqual(len(tasks), 1)
+    self.assertEqual(tasks[0].url, util.ingest_library_task('@@npm', 'package'))
+
 class PreviewCommitTest(ApiTestBase):
   def setUp(self):
     ApiTestBase.setUp(self)

--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -75,7 +75,11 @@ class Library(ndb.Model):
 
   @staticmethod
   def github_from_url(path):
-    return (path, path)
+    path = re.sub('git://github.com/', '', path)
+    path = re.sub(r'(git\+)?https?:\/\/github.com\/', '', path)
+    path = re.sub(r'\.git$', '', path)
+    split = path.split('/')
+    return (split[0], split[1])
 
   @staticmethod
   def maybe_create_with_kind(owner, repo, kind):

--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -37,8 +37,8 @@ class Author(ndb.Model):
   updated = ndb.DateTimeProperty(auto_now=True)
 
 class Library(ndb.Model):
-  github_owner = ndb.StringProperty(indexed = False)
-  github_repo = ndb.StringProperty(indexed = False)
+  github_owner = ndb.StringProperty(indexed=False)
+  github_repo = ndb.StringProperty(indexed=False)
   github_access_token = ndb.StringProperty(indexed=False)
 
   kind = ndb.StringProperty(default='element')

--- a/src/datamodel.py
+++ b/src/datamodel.py
@@ -37,6 +37,8 @@ class Author(ndb.Model):
   updated = ndb.DateTimeProperty(auto_now=True)
 
 class Library(ndb.Model):
+  github_owner = ndb.StringProperty(indexed = False)
+  github_repo = ndb.StringProperty(indexed = False)
   github_access_token = ndb.StringProperty(indexed=False)
 
   kind = ndb.StringProperty(default='element')
@@ -70,6 +72,10 @@ class Library(ndb.Model):
   @staticmethod
   def id(owner, repo):
     return '%s/%s' % (owner.lower(), repo.lower())
+
+  @staticmethod
+  def github_from_url(path):
+    return (path, path)
 
   @staticmethod
   def maybe_create_with_kind(owner, repo, kind):

--- a/src/datamodel_test.py
+++ b/src/datamodel_test.py
@@ -95,3 +95,9 @@ class DependencyTests(TestBase):
     self.assertEqual(dependency.owner, 'owner')
     self.assertEqual(dependency.repo, 'repo')
     self.assertEqual(dependency.version, '*')
+
+class LibraryGithubFromUrl(TestBase):
+  def test_from_url(self):
+    self.assertEqual(Library.github_from_url('owner/repo'), ('owner', 'repo'))
+    self.assertEqual(Library.github_from_url('git+https://github.com/owner/repo.git'), ('owner', 'repo'))
+    self.assertEqual(Library.github_from_url('git://github.com/owner/repo.git'), ('owner', 'repo'))

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -457,6 +457,26 @@ class AddTest(ManageTestBase):
     self.assertEqual(len(tasks), 1)
     self.assertEqual(tasks[0].url, util.ingest_library_task('org', 'repo'))
 
+  def test_add_scope(self):
+    token = self.app.get('/manage/token').normal_body
+    response = self.app.get('/manage/add/@scope/package', params={'token': token})
+    self.assertEqual(response.status_int, 200)
+    self.assertEqual(response.normal_body, 'OK')
+
+    tasks = self.tasks.get_filtered_tasks()
+    self.assertEqual(len(tasks), 1)
+    self.assertEqual(tasks[0].url, util.ingest_library_task('@scope', 'package'))
+
+  def test_add_no_scope(self):
+    token = self.app.get('/manage/token').normal_body
+    response = self.app.get('/manage/add/@@npm/package', params={'token': token})
+    self.assertEqual(response.status_int, 200)
+    self.assertEqual(response.normal_body, 'OK')
+
+    tasks = self.tasks.get_filtered_tasks()
+    self.assertEqual(len(tasks), 1)
+    self.assertEqual(tasks[0].url, util.ingest_library_task('@@npm', 'package'))
+
 class IngestLibraryTest(ManageTestBase):
   def test_ingest_element(self):
     self.respond_to_github('https://raw.githubusercontent.com/org/repo/master/bower.json', '{"license": "MIT"}')

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -674,7 +674,7 @@ class IngestLibraryTest(ManageTestBase):
 
 class IngestNPMLibraryTest(ManageTestBase):
   def test_ingest_element(self):
-    self.respond_to('https://registry.npmjs.org/@scope%2fpackage', '{"repository": { "url": "git+https://github.com/org/repo.git"}}');
+    self.respond_to('https://registry.npmjs.org/@scope%2fpackage', '{"repository": { "url": "git+https://github.com/org/repo.git"}}')
     self.respond_to_github('https://raw.githubusercontent.com/org/repo/master/bower.json', '{"license": "MIT"}')
     self.respond_to_github('https://api.github.com/repos/org/repo', '{"owner":{"login":"org"},"name":"repo"}')
     self.respond_to_github('https://api.github.com/repos/org/repo/contributors', '["a"]')
@@ -703,7 +703,7 @@ class IngestNPMLibraryTest(ManageTestBase):
     ], [task.url for task in tasks])
 
   def test_ingest_no_package(self):
-    self.respond_to('https://registry.npmjs.org/nopackage', {'status': 404});
+    self.respond_to('https://registry.npmjs.org/nopackage', {'status': 404})
     response = self.app.get(util.ingest_library_task('@@npm', 'nopackage'), headers={'X-AppEngine-QueueName': 'default'})
 
     self.assertEqual(response.status_int, 200)

--- a/src/util.py
+++ b/src/util.py
@@ -31,8 +31,10 @@ def github_url(prefix, owner=None, repo=None, detail=None, params=None):
 def content_url(owner, repo, version, path):
   return 'https://raw.githubusercontent.com/%s/%s/%s/%s' % (owner, repo, version, path)
 
-def npm_registry_url(scope, repo):
-  return 'https://registry.npmjs.org/%s/%s' % (scope, repo)
+def npm_registry_url(scope, package):
+  if scope == '@@npm':
+    return 'https://registry.npmjs.org/%s' % package
+  return 'https://registry.npmjs.org/%s%s%s' % (scope, '%2f', package)
 
 def analyze_library_task(owner, repo, latest=False):
   return '/task/analyze/%s/%s/%s' % (owner, repo, latest)

--- a/src/util.py
+++ b/src/util.py
@@ -31,6 +31,9 @@ def github_url(prefix, owner=None, repo=None, detail=None, params=None):
 def content_url(owner, repo, version, path):
   return 'https://raw.githubusercontent.com/%s/%s/%s/%s' % (owner, repo, version, path)
 
+def npm_registry_url(scope, repo):
+  return 'https://registry.npmjs.org/%s/%s' % (scope, repo)
+
 def analyze_library_task(owner, repo, latest=False):
   return '/task/analyze/%s/%s/%s' % (owner, repo, latest)
 


### PR DESCRIPTION
Part of #531 

In this change:
 * allows the publish API to accept packages as well as GitHub repos
 * unscoped packages are stored under `@@npm`
 * `update_metadata` calls into the registry to retrieve github repository
 * GitHub repository is stored on the `Library` entity

Next:
 * update version ingestion to pull from package
 * update tag lookup to pull from registry metadata
 * update analysis to pull from package and `npm install`