### PR TITLE
Patch greedy subtitle hiding

### DIFF
--- a/client/src/catalog-element-readme.html
+++ b/client/src/catalog-element-readme.html
@@ -22,7 +22,7 @@
         color: inherit;
       }
 
-      article.markdown-body > h2:first-of-type, article.markdown-body > h1:first-of-type {
+      article.markdown-body > h1:first-of-type {
         display: none;
       }
 


### PR DESCRIPTION
Addresses https://github.com/webcomponents/webcomponents.org/issues/928

Was going to do a proper JS fix, but don't have time to setup the buildstep for local testing atm.

@samuelli logic would have looked something like this, if you wanted to throw it in yourself (somewhere around [this line](https://github.com/webcomponents/webcomponents.org/blob/master/client/src/catalog-element-readme.html#L233))

```js
var headings = [].slice.call(Polymer.dom(this.$.contents).querySelectorAll('h1,h2'));
var elementNameExp = this.data.repo.split('-').join('[ -]');
var headingsRegex = new RegExp(elementNameExp, 'i');
        
headings.find(function(element) {
  element.innerText.match(headingsRegex);
}).style.display = 'none';
```