### PR TITLE
Client UI Fix: Add padding/margin for author sidebar in large view 

### DIFF
--- a/client/src/catalog-styles.html
+++ b/client/src/catalog-styles.html
@@ -89,11 +89,14 @@
         flex: 10 0 270px;
         max-width: calc(100% - 270px);
         min-width: 300px;
+        padding: 0 16px;
       }
 
       .sidebar {
         flex: 0 0 270px;
         order: 2;
+        margin: 16px;
+        margin-top: 0;
       }
 
       .sidebar h3 {


### PR DESCRIPTION
Fixes #1014

I chose to follow the established padding/margin used in the media query styles for affected containers.

<img width="784" alt="cursor_and_tsaidavid" src="https://user-images.githubusercontent.com/12259854/27765974-e3da792e-5e75-11e7-92a2-e080d594afc5.png">
