### PR TITLE
Fix starring triggers

### DIFF
--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -551,11 +551,6 @@
         this._shaRegex = /^[0-9a-f]{20,}$/;
       },
 
-      ready: function() {
-        if (this.queryParams && this.queryParams.code)
-          this._starRepo();
-      },
-
       _shouldShowEditor: function(queryParams, prefix) {
         return 'editing' in queryParams || prefix == '/preview';
       },
@@ -795,6 +790,9 @@
         this.fire('meta-set', {key: 'name', value: 'twitter:card', content: 'summary'});
 
         this.async(this._updateActiveLinks);
+
+        if (this.queryParams && this.queryParams.code)
+          this._starRepo();
       },
 
       _pageTitle: function(pages, pagePath) {

--- a/client/test/catalog-element.html
+++ b/client/test/catalog-element.html
@@ -117,7 +117,6 @@
         flush(function() {
           assert(!elementPage._isStarred(), 'should not be starred');
           assert.equal(elementPage.data.stars, 0);
-          elementPage._starRepo();
           server.respond();
           assert(elementPage._isStarred(), 'should be starred');
           assert.equal(elementPage.data.stars, 1);


### PR DESCRIPTION
Fixes #1020. 

This was regressed in #1010. As this added NPM support, the metadata from the API was required for a starring API call to be accurate. This meant the triggers for the starring method needed to be moved from the page loaded (ready) to when we received the metadata.