### PR TITLE
Update GitHub license API reading to match updated API

### DIFF
--- a/src/manage.py
+++ b/src/manage.py
@@ -343,8 +343,10 @@ class LibraryTask(RequestHandler):
 
     spdx_identifier = None
     github_license = metadata.get('license')
-    if github_license is not None:
-      spdx_identifier = licenses.validate_spdx(github_license.get('key', 'MISSING'))
+
+    # GitHub may now return as a license object instead.
+    if isinstance(github_license, dict):
+      spdx_identifier = licenses.validate_spdx(github_license.get('spdx_id', 'MISSING'))
 
     if spdx_identifier is None and bower_json is not None:
       license_name = bower_json.get('license')


### PR DESCRIPTION
Fixes #1023.

GitHub's [license API](https://developer.github.com/v3/licenses) is under preview and subject to change. They have updated it to return a [license object instead](https://developer.github.com/v3/licenses/#get-a-repositorys-license) with a SPDX identifier in it. This change updates to match that behavior.