### PR TITLE
Change export markdown to download

### DIFF
--- a/client/src/custom-element-demo.html
+++ b/client/src/custom-element-demo.html
@@ -297,12 +297,7 @@
           '```',
         ].join('\n');
 
-        // Initiate a download of the markdown. Opening data URIs in the top frame
-        // was deprecated.
-        var element = document.createElement('a');
-        element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(source));
-        element.setAttribute('download', 'inline-demo.md');
-        element.click();
+        window.open(URL.createObjectURL(new Blob([source]), {type: 'text/plain'}));
         this.fire('event', {category: 'Inline demo', action: 'export'});
       },
 

--- a/client/src/custom-element-demo.html
+++ b/client/src/custom-element-demo.html
@@ -296,7 +296,13 @@
           code,
           '```',
         ].join('\n');
-        window.open('data:text/plain;base64,' + btoa(source));
+
+        // Initiate a download of the markdown. Opening data URIs in the top frame
+        // was deprecated.
+        var element = document.createElement('a');
+        element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(source));
+        element.setAttribute('download', 'inline-demo.md');
+        element.click();
         this.fire('event', {category: 'Inline demo', action: 'export'});
       },
 


### PR DESCRIPTION
Fixes #1074.

Opening data URIs in a top level frame has been disabled in Chrome.