### PR TITLE
Add links to corresponding accepted specifications

### DIFF
--- a/client/src/browser-table.html
+++ b/client/src/browser-table.html
@@ -227,7 +227,9 @@
         </div>
       </div>
       <div class="row">
-        <div label="Templates"><svg viewBox="0 0 26 22"><use xlink:href="/sprite.octicons.svg#template"></use></svg></div>
+        <a href="https://html.spec.whatwg.org/multipage/scripting.html#the-template-element" target="__blank" rel="noopener">
+          <div label="Templates"><svg viewBox="0 0 26 22"><use xlink:href="/sprite.octicons.svg#template"></use></svg></div>
+        </a>
         <a title="Stable" href="https://www.chromestatus.com/feature/5207287069147136"></a>
         <a title="Stable" href="https://www.chromestatus.com/feature/5207287069147136"></a>
         <a title="Stable" href="https://webkit.org/status/#feature-template-element"></a>
@@ -235,7 +237,9 @@
         <a title="Stable" href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/templateelement/"></a>
       </div>
       <div class="row">
-        <div label="Custom elements"><svg viewBox="0 0 26 22"><use xlink:href="/sprite.octicons.svg#element"></use></svg></div>
+        <a href="https://w3c.github.io/webcomponents/spec/custom/" target="__blank" rel="noopener">
+          <div label="Custom elements"><svg viewBox="0 0 26 22"><use xlink:href="/sprite.octicons.svg#element"></use></svg></div>
+        </a>
         <a title="Stable" href="https://www.chromestatus.com/feature/4696261944934400"></a>
         <a title="Stable" href="https://www.chromestatus.com/feature/4696261944934400"></a>
         <a title="Stable" href="https://webkit.org/status/#feature-custom-elements"></a>
@@ -249,7 +253,9 @@
         </a>
       </div>
       <div class="row">
-        <div label="Shadow DOM"><svg viewBox="0 0 26 22"><use xlink:href="/sprite.octicons.svg#shadow"></use></svg></div>
+        <a href="https://dom.spec.whatwg.org/#shadow-trees" target="__blank" rel="noopener">
+          <div label="Shadow DOM"><svg viewBox="0 0 26 22"><use xlink:href="/sprite.octicons.svg#shadow"></use></svg></div>
+        </a>
         <a title="Stable" href="https://www.chromestatus.com/feature/4667415417847808"></a>
         <a title="Stable" href="https://www.chromestatus.com/feature/4667415417847808"></a>
         <a title="Stable" href="https://webkit.org/status/#feature-shadow-dom"></a>
@@ -263,7 +269,9 @@
         </a>
       </div>
       <div class="row">
-        <div label='<script type="module">'><svg viewBox="0 0 26 22"><use xlink:href="/sprite.octicons.svg#import"></use></svg></div>
+        <a href="https://html.spec.whatwg.org/multipage/webappapis.html#integration-with-the-javascript-module-system" target="__blank" rel="noopener">
+          <div label='<script type="module">'><svg viewBox="0 0 26 22"><use xlink:href="/sprite.octicons.svg#import"></use></svg></div>
+        </a>
         <a title="Stable" href="https://www.chromestatus.com/feature/5365692190687232"></a>
         <a title="Stable" href="https://www.chromestatus.com/feature/5684934484164608"></a>
         <a title="Stable" href="https://webkit.org/status/#feature-modules"></a>


### PR DESCRIPTION
I am always googling my way to the correct location of the specifications. Seems like a nice fit for this table to also provide a link to the correct specification location.