### PR TITLE
Add data-version for FLAG IN comment

### DIFF
--- a/client/src/browser-table.html
+++ b/client/src/browser-table.html
@@ -125,7 +125,7 @@
         background:  url("data:image/svg+xml;utf8,<svg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 22 22%27 version=%271.1%27 aria-hidden=%27true%27><circle fill=%27white%27 cx=%2750%%27 cy=%2750%%27 r=%272%27></circle></svg>"), #aaa;
       }
 
-      [type="Stable"], [title="Stable"]:after {
+      [type="Stable"]:after, [title="Stable"]:after {
         color: hsla(101,61%,32%,1);
         content: 'stable';
       }
@@ -140,7 +140,7 @@
         content: 'on hold';
       }
 
-      [type="Developing"], [title="Developing"]:after {
+      [type="Developing"]:after, [title="Developing"]:after {
         color: hsla(37,91%,34%,1);
         content: 'Developing';
       }
@@ -148,6 +148,10 @@
       [title="Under consideration"]:after {
         color: hsla(0,0%,46%,1);
         content: 'Considering';
+      }
+      
+      [data-version]:after {
+        content: 'FLAG IN ' attr(data-version);
       }
 
       @media (max-width: 900px) {
@@ -160,7 +164,8 @@
         [title="Polyfill"]:after,
         [title="On hold"]:after,
         [title="Developing"]:after,
-        [title="Under consideration"]:after {
+        [title="Under consideration"]:after,
+        [data-version]:after {
           content: none !important;
         }
 
@@ -279,7 +284,7 @@
         <a title="Stable" href="https://www.chromestatus.com/feature/5365692190687232"></a>
         <a title="Stable" href="https://www.chromestatus.com/feature/5684934484164608"></a>
         <a title="Stable" href="https://webkit.org/status/#feature-modules"></a>
-        <a type="Developing" title href="https://developer.mozilla.org/en-US/Firefox/Experimental_features#JavaScript">Flag in 54</a>
+        <a type="Developing" data-version="54" title href="https://developer.mozilla.org/en-US/Firefox/Experimental_features#JavaScript"></a>
         <a title="Stable" href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/moduleses6/"></a>
       </div>
       <div class="row">


### PR DESCRIPTION
Manually inputting the flag text lead to the table looking messy when viewport width was small.
Now you can add data-version="[VER]" to any of the marks to change the text to "FLAG IN [VER]"
This new text will behave the same as all text and vanish when the screen is small enough.

See issue #1098