### PR TITLE
Removed margin: 0 auto;

### DIFF
--- a/client/src/catalog-app.html
+++ b/client/src/catalog-app.html
@@ -86,7 +86,6 @@
 
       #pages, #footer-content, #toolbar-search-container, #toolbar-nav-container {
         max-width: 1080px;
-        margin: 0 auto;
         width: 100%;
       }
 


### PR DESCRIPTION
This line seems redundant in all browsers (Chrome, Firefox and Edge) but breaks alignment in IE.
Removing it fixes the alignment for IE and changes nothing in the other browsers

See issues #835 and #1095