### PR TITLE
Correcting syntax for CSS selectors in host element

### DIFF
--- a/client/src/catalog-search-box.html
+++ b/client/src/catalog-search-box.html
@@ -149,7 +149,7 @@
                     0 2px 4px -1px rgba(0, 0, 0, 0.4);
       }
 
-      :host:not(.expanded) > #results {
+      :host(:not(.expanded)) > #results {
         display: none;
       }
 


### PR DESCRIPTION
CSS selectors need to be wrapped in parentheses, I've added this.

[Documentation](https://www.polymer-project.org/2.0/docs/devguide/style-shadow-dom#use-css-selectors-to-style-the-host-element)
See issue #939 