### PR TITLE
Empty iframe src on _demoCanceled

### DIFF
--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -745,6 +745,7 @@
           history.replaceState({}, document.title, this.route.prefix + '/' + this._scopePackage + this.versionRoute);
           this.fire('location-changed');
         }
+        this.$['demo-frame'].removeAttribute('src');
         this._dialogDemoLoading = false;
       },
 


### PR DESCRIPTION
When closing a demo dialog the iframe within it is still active meaning actions, audio playback/recording etc, will continue after the demo is 'closed'. When a demo is open the src is set regardless of its current value, causing the frame to refresh, as this is the case there is no need to keep the src once the demo is closed.

See issue #1065