### PR TITLE
Change empty results pages title

### DIFF
--- a/client/src/catalog-list.html
+++ b/client/src/catalog-list.html
@@ -123,6 +123,11 @@
           type: Boolean,
           notify: true,
         },
+        totalResults: {
+          type: Number,
+          computed: '_sum(_elements.count, _collections.count)',
+          reflectToAttribute: true,
+        },
         _collectionsLoading: {
           value: false,
           type: Boolean,
@@ -151,6 +156,10 @@
       _params: function(count, noscore) {
         var params = '?limit=' + count + '&count';
         return noscore ? params + '&noscore' : params;
+      },
+
+      _sum: function(a, b) {
+        return a + b;
       },
 
       _and: function(a, b) {

--- a/client/src/catalog-search.html
+++ b/client/src/catalog-search.html
@@ -11,7 +11,7 @@
     <h1 class="page-title">[[_title(query, pageTitle)]]</h1>
 
     <div id="header-main" class="main-content">
-      <catalog-list id="list" query="[[query]]" base-urls="[[baseUrls]]" loading="{{loading}}" disabled="[[!visible]]"></catalog-list>
+      <catalog-list id="list" totalResults="{{totalResults}}" query="[[query]]" base-urls="[[baseUrls]]" loading="{{loading}}" disabled="[[!visible]]"></catalog-list>
     </div>
 
   </template>
@@ -41,7 +41,10 @@
       },
 
       _title: function(query, title) {
-        return title ? title : 'Results for "' + query + '"';
+        if (this.totalResults || title)
+          return title ? title : 'Results for "' + query + '"';
+
+        return 'No results for "' + query + '"';
       },
     });
   </script>


### PR DESCRIPTION
A results page with no results will now say
No results for "some query"

See issue #1050 