### PR TITLE
Hidden support

### DIFF
--- a/analysis/test/resources/polymer2/shop-image.html
+++ b/analysis/test/resources/polymer2/shop-image.html
@@ -25,6 +25,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         background-position: center;
       }
 
+      :host([hidden]) {
+        display: none;
+      }
+
       img {
         @apply --layout-fit;
         max-width: 100%;

--- a/client/src/catalog-api-doc.html
+++ b/client/src/catalog-api-doc.html
@@ -14,6 +14,10 @@
         word-wrap: break-word;
       }
 
+      :host([hidden]) {
+        display: none;
+      }
+
       [hidden] {
         display: none !important;
       }

--- a/client/src/catalog-app.html
+++ b/client/src/catalog-app.html
@@ -79,6 +79,10 @@
         --syntax-guide: hsla(var(--syntax-hue), 14%, 71%, 0.85);
       }
 
+      :host([hidden]) {
+        display: none;
+      }
+
       :host([page=home]) {
         background: linear-gradient(168deg, transparent 80vh, #F3F4F5 80vh, white 100vh),
                     var(--bg-gradient), white;

--- a/client/src/catalog-element-readme.html
+++ b/client/src/catalog-element-readme.html
@@ -10,6 +10,10 @@
         display: block;
       }
 
+      :host([hidden]) {
+        display: none;
+      }
+
       /** Readme.md override */
       .markdown-body .anchor {
         margin-left: 0;

--- a/client/src/catalog-item.html
+++ b/client/src/catalog-item.html
@@ -12,6 +12,10 @@
         background: white;
       }
 
+      :host([hidden]) {
+        display: none;
+      }
+
       :host(:hover:not(:active)) {
         background: hsla(0, 0%, 98%, 1);
       }

--- a/client/src/catalog-list.html
+++ b/client/src/catalog-list.html
@@ -15,6 +15,10 @@
         display: block;
       }
 
+      :host([hidden]) {
+        display: none;
+      }
+
       h1.section-header {
         margin-top: 16px;
       }

--- a/client/src/collection-card.html
+++ b/client/src/collection-card.html
@@ -12,6 +12,10 @@
         overflow: hidden;
       }
 
+      :host([hidden]) {
+        display: none;
+      }
+
       :host(.box:hover:not(:active)) {
         box-shadow: 0 1px 4px 0 var(--shadow-color, hsla(0, 0%, 0%, 0.1)), 0 0px 4px 0 var(--shadow-color, hsla(0, 0%, 0%, 0.1)), 0 0 20px 0 hsla(0, 0%, 0%, 0.1) !important;
       }

--- a/client/src/github-info.html
+++ b/client/src/github-info.html
@@ -8,6 +8,10 @@
         color: var(--theme-blue-grey);
       }
 
+      :host([hidden]) {
+        display: none;
+      }
+
       section {
         padding: 12px 16px;
         border-top: 1px solid #ededed;

--- a/client/src/mark-down.html
+++ b/client/src/mark-down.html
@@ -23,6 +23,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         display: block;
       }
 
+      :host([hidden]) {
+        display: none;
+      }
+
       #content p:first-child:last-child {
         margin: 0;
       }


### PR DESCRIPTION
Added some code to enable the hidden attribute in when using shadowdom, as opposed to shadydom.

```css
:host([hidden]) {
  display: none;
}
```

https://developers.google.com/web/fundamentals/web-components/best-practices#add-a-host-display-style-that-respects-the-hidden-attribute

See issue #939 