### PR TITLE
Table alignment for phones

### DIFF
--- a/client/src/browser-table.html
+++ b/client/src/browser-table.html
@@ -195,16 +195,20 @@
         .row :last-child {
           flex: 0 0 30px !important;
         }
+        
+        [spec] {
+          position: absolute;
+          margin-top: -51px;
+          background: white;
+        }
 
         div[label] {
           flex: 1 0 40px !important;
         }
 
         div[label]:after {
-          position: absolute;
-          margin-top: -51px;
           padding-right: 8px;
-          background: white;
+          white-space: nowrap;
         }
       }
     </style>


### PR DESCRIPTION
Sorted table alignment for phones so ticks appear below correct browser icon.

**Old Layout**
![phone_alignment_old](https://user-images.githubusercontent.com/3534427/36141844-2dd33e78-109e-11e8-9f5f-803602fe9e4b.PNG)

**Revised Layout**
![phone_alignment](https://user-images.githubusercontent.com/3534427/36141867-3f9ef7d2-109e-11e8-8e75-6719d3541fab.PNG)
