### PR TITLE
Suppress bower equivalent when publishing NPM package

### DIFF
--- a/src/manage.py
+++ b/src/manage.py
@@ -273,8 +273,8 @@ class LibraryTask(RequestHandler):
         raise RequestAborted('repo has been renamed to %s', Library.id(self.owner, self.repo))
 
       # If adding a NPM package that a Bower repo already points to, remove the bower one.
-      bowerLibrary = Library.id(self.owner, self.repo)
-      if is_npm_package and bowerLibrary is not None:
+      bower_library_id = Library.id(self.owner, self.repo)
+      if is_npm_package and bower_library_id is not None:
         logging.info('removing bower repo %s', Library.id(self.owner, self.repo))
         task_url = util.suppress_library_task(self.owner, self.repo)
         util.new_task(task_url, target='manage')

--- a/src/util.py
+++ b/src/util.py
@@ -78,7 +78,10 @@ def ingest_analysis_task(owner, repo, version, sha=None):
     return '/task/analyze/%s/%s/%s/%s' % (owner, repo, version, sha)
   return '/task/analyze/%s/%s/%s' % (owner, repo, version)
 
-def delete_task(owner, repo, version):
+def suppress_library_task(owner, repo):
+  return '/task/suppress/%s/%s' % (owner, repo)
+
+def delete_version_task(owner, repo, version):
   return '/task/delete/%s/%s/%s' % (owner, repo, version)
 
 def new_task(url, params=None, target=None, transactional=False, queue_name='default'):


### PR DESCRIPTION
When publishing an NPM package, we may find an equivalent repo that was published under Bower. As we create a new `Library` instance to represent the NPM package, we need to remove the Bower repo to remove duplication.

Deleting a repo in this case represents an attack vector, as we use the GitHub repo specified in `package.json`, which may be malicious. To achieve the same behavior without permanent damage, suppression is used. Entities under suppression will not appear across the site, but remain intact and can be easily restored.

The reason it is a separate task is because the existing architecture requires singular database transactions. Since this acts on a different `Library` entity, it needs to be pulled into its own transactional task.