### PR TITLE
Filter analysis result

### DIFF
--- a/analysis/package-lock.json
+++ b/analysis/package-lock.json
@@ -3107,11 +3107,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
     },
-    "ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
-    },
     "negotiator": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",

--- a/analysis/src/analyzer.js
+++ b/analysis/src/analyzer.js
@@ -69,10 +69,12 @@ class AnalyzerRunner {
         analyzer.analyzePackage().then(analysis => {
           // Get source paths for all features.
           const features = Array.from(analysis.getFeatures());
-          const paths = features.map((f) => f.sourceRange && f.sourceRange.file);
+          const paths = features
+            .filter((f) => f.sourceRange !== undefined)
+            .map((f) => f.sourceRange.file);
           const uniquePaths = new Set(paths);
 
-          const shouldOuputFeature = (feature) => {
+          const shouldOutputFeature = (feature) => {
             if (!isInPackage(feature)) {
               return false;
             }
@@ -85,13 +87,13 @@ class AnalyzerRunner {
 
             const strippedBaseName = fileMatch[0] + '.' + fileMatch[fileMatch.length - 1];
             // Don't use pathlib.join() as that will strip file:/// protocol.
-            if (!uniquePaths.has(pathlib.dirname(path) + '/' + strippedBaseName)) {
+            if (!uniquePaths.has(pathlib.dirname(path) + pathlib.sep + strippedBaseName)) {
               return true;
             }
             return false;
           };
 
-          resolve(generateAnalysis(analysis, analyzer.urlResolver, shouldOuputFeature));
+          resolve(generateAnalysis(analysis, analyzer.urlResolver, shouldOutputFeature));
         }).catch(function(error) {
           Ana.fail('analyzer/analyze', paths, error);
           reject({retry: true, error: error});


### PR DESCRIPTION
Filtering files for analysis was not sufficient. If a file depends on a file that was not found in the search, it can still end up in the analyzed output. This change filters results before final output of analyzing results. Filtering before is still useful as that forms analyzer's search roots and can help prevent some additional overhead associated with having to analyze additional files.