### PR TITLE
Update Firefox Platform Status links

### DIFF
--- a/client/src/browser-table.html
+++ b/client/src/browser-table.html
@@ -288,7 +288,7 @@
         <a title="Stable" href="https://www.chromestatus.com/feature/5365692190687232"></a>
         <a title="Stable" href="https://www.chromestatus.com/feature/5684934484164608"></a>
         <a title="Stable" href="https://webkit.org/status/#feature-modules"></a>
-        <a type="Developing" data-version="54" title href="https://developer.mozilla.org/en-US/Firefox/Experimental_features#JavaScript"></a>
+        <a type="Developing" data-version="54" title href="https://platform-status.mozilla.org/#javascript-modules"></a>
         <a title="Stable" href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/moduleses6/"></a>
       </div>
       <div class="row">

--- a/client/src/browser-table.html
+++ b/client/src/browser-table.html
@@ -149,10 +149,6 @@
         color: hsla(0,0%,46%,1);
         content: 'Considering';
       }
-      
-      [data-version]:after {
-        content: 'FLAG IN ' attr(data-version);
-      }
 
       @media (max-width: 900px) {
         #container {
@@ -288,7 +284,7 @@
         <a title="Stable" href="https://www.chromestatus.com/feature/5365692190687232"></a>
         <a title="Stable" href="https://www.chromestatus.com/feature/5684934484164608"></a>
         <a title="Stable" href="https://webkit.org/status/#feature-modules"></a>
-        <a type="Developing" data-version="54" title href="https://platform-status.mozilla.org/#javascript-modules"></a>
+        <a type="Developing" title href="https://platform-status.mozilla.org/#javascript-modules"></a>
         <a title="Stable" href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/moduleses6/"></a>
       </div>
       <div class="row">


### PR DESCRIPTION
The [Firefox Platform Status website](https://platform-status.mozilla.org/) now has information for every feature on the [WebComponents website](https://webcomponents.org/), including [`<script type="module">`](https://platform-status.mozilla.org/#javascript-modules) (which is shipping in Firefox 60).

### See also:
- mozilla/platform-status#520
- mdn/browser-compat-data#1667