### PR TITLE
Center the main page footer

### DIFF
--- a/client/src/catalog-app.html
+++ b/client/src/catalog-app.html
@@ -385,6 +385,7 @@
         color: white;
         padding: 32px 0;
         flex-wrap: wrap;
+        margin: 0 auto;
       }
 
       #footer-content section {


### PR DESCRIPTION
Right now, the footer is left aligned, this PR instead centers it, so that it feels more aesthetically balanced.