### PR TITLE
Correct Firefox JavaScript Modules link `title` attribute

### DIFF
--- a/client/src/browser-table.html
+++ b/client/src/browser-table.html
@@ -284,7 +284,7 @@
         <a title="Stable" href="https://www.chromestatus.com/feature/5365692190687232"></a>
         <a title="Stable" href="https://www.chromestatus.com/feature/5684934484164608"></a>
         <a title="Stable" href="https://webkit.org/status/#feature-modules"></a>
-        <a type="Developing" title href="https://platform-status.mozilla.org/#javascript-modules"></a>
+        <a title="Developing" href="https://platform-status.mozilla.org/#javascript-modules"></a>
         <a title="Stable" href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/moduleses6/"></a>
       </div>
       <div class="row">


### PR DESCRIPTION
This slipped through the cracks in [`9773a62`](https://github.com/webcomponents/webcomponents.org/pull/1130/commits/9773a6250cd2b4853958e29d62be5301e8c05068#diff-9bfb31f42b1eb6de17a3d6d055bfed60R287).

### Before:
https://github.com/webcomponents/webcomponents.org/blob/9773a6250cd2b4853958e29d62be5301e8c05068/client/src/browser-table.html#L287

### After:
https://github.com/webcomponents/webcomponents.org/blob/1009932118d9594bb3850682f760bda6f694f417/client/src/browser-table.html#L287