### PR TITLE
Handle multi-package repositories

### DIFF
--- a/src/manage.py
+++ b/src/manage.py
@@ -747,32 +747,34 @@ class IngestVersion(RequestHandler):
     super(IngestVersion, self).error(error_string)
 
   def update_readme(self, is_npm_package):
-    github_owner = self.owner
-    github_repo = self.repo
-
     if is_npm_package:
-      # Load parent library object to get the repo information
+      # Load registry metadata to fetch readme path.
       library = Library.get_by_id(Library.id(self.owner, self.repo))
-      github_owner = library.github_owner
-      github_repo = library.github_repo
+      registry_metadata = json.loads(library.registry_metadata) if library.registry_metadata else None
+      readmePath = registry_metadata.get('readmeFilename', 'README.md')
+      response = util.unpkg_get(self.owner, self.repo, self.version, readmePath)
+      readme = response.content
+      print readme
+    else:
+      # Load readme from GitHub endpoint.
+      response = util.github_get('repos', self.owner, self.repo, 'readme', params={"ref": self.sha})
 
-    print github_owner, github_repo
-    response = util.github_get('repos', github_owner, github_repo, 'readme', params={"ref": self.sha})
+      if response.status_code == 200:
+        readme = base64.b64decode(json.loads(response.content)['content'])
+      elif response.status_code == 404:
+        readme = None
+      else:
+        return self.retry('error fetching readme (%d)' % response.status_code)
 
-    if response.status_code == 200:
-      readme = base64.b64decode(json.loads(response.content)['content'])
-
+    if readme is not None:
+      # Store the raw readme markdwon contents.
       try:
         Content(parent=self.version_key, id='readme', content=readme,
                 status=Status.ready, etag=response.headers.get('ETag', None)).put()
       except db.BadValueError:
         return self.error("Could not store README.md as a utf-8 string", ErrorCodes.Version_utf)
-    elif response.status_code == 404:
-      readme = None
-    else:
-      return self.retry('error fetching readme (%d)' % response.status_code)
 
-    if readme is not None:
+      # Convert markdown to HTML and store the result.
       response = util.github_markdown(readme)
       if response.status_code == 200:
         Content(parent=self.version_key, id='readme.html', content=response.content,

--- a/src/manage.py
+++ b/src/manage.py
@@ -754,7 +754,6 @@ class IngestVersion(RequestHandler):
       readme_path = registry_metadata.get('readmeFilename', 'README.md')
       response = util.unpkg_get(self.owner, self.repo, self.version, readme_path)
       readme = response.content
-      print readme
     else:
       # Load readme from GitHub endpoint.
       response = util.github_get('repos', self.owner, self.repo, 'readme', params={"ref": self.sha})
@@ -767,7 +766,7 @@ class IngestVersion(RequestHandler):
         return self.retry('error fetching readme (%d)' % response.status_code)
 
     if readme is not None:
-      # Store the raw readme markdwon contents.
+      # Store the raw readme markdown.
       try:
         Content(parent=self.version_key, id='readme', content=readme,
                 status=Status.ready, etag=response.headers.get('ETag', None)).put()

--- a/src/manage.py
+++ b/src/manage.py
@@ -491,7 +491,7 @@ class LibraryTask(RequestHandler):
     tags.sort(versiontag.compare)
     # Create a tag map of tag to sha
     tag_map = dict((tag, versions.get(tag).get('gitHead', '')) for tag in tags
-                   if versiontag.is_valid(tag) and versions.get(tag).get('gitHead'))
+                   if versiontag.is_valid(tag))
 
     if self.library.tags is None or self.library.tags != tags:
       self.library.library_dirty = True

--- a/src/manage.py
+++ b/src/manage.py
@@ -751,8 +751,8 @@ class IngestVersion(RequestHandler):
       # Load registry metadata to fetch readme path.
       library = Library.get_by_id(Library.id(self.owner, self.repo))
       registry_metadata = json.loads(library.registry_metadata) if library.registry_metadata else None
-      readmePath = registry_metadata.get('readmeFilename', 'README.md')
-      response = util.unpkg_get(self.owner, self.repo, self.version, readmePath)
+      readme_path = registry_metadata.get('readmeFilename', 'README.md')
+      response = util.unpkg_get(self.owner, self.repo, self.version, readme_path)
       readme = response.content
       print readme
     else:

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -709,13 +709,19 @@ class IngestLibraryTest(ManageTestBase):
     self.assertEqual(bower.get_json(), {})
 
   def test_ingest_version_npm(self):
+    registry_metadata = """{
+      "description": "mydescription",
+      "keywords": ["my-keyword"],
+      "readmeFilename": "README"
+    }"""
     library_key = Library(id='@scope/package',
                           github_owner='owner',
                           github_repo='repo',
-                          metadata='{"full_name": "NSS Bob", "stargazers_count": 420, "subscribers_count": 419, "forks": 418, "updated_at": "2011-8-10T13:47:12Z"}').put()
+                          metadata='{"full_name": "NSS Bob", "stargazers_count": 420, "subscribers_count": 419, "forks": 418, "updated_at": "2011-8-10T13:47:12Z"}',
+                          registry_metadata=registry_metadata).put()
     Version(id='1.0.0', parent=library_key, sha='sha').put()
 
-    self.respond_to_github(r'https://api.github.com/repos/owner/repo/readme\?ref=sha', '{"content":"%s"}' % b64encode('readme as markdown'))
+    self.respond_to_github('https://unpkg.com/@scope/package@1.0.0/README', 'readme as markdown')
     self.respond_to_github('https://api.github.com/markdown', '<html>Converted readme</html>')
 
     response = self.app.get(util.ingest_version_task('@scope', 'package', '1.0.0'), headers={'X-AppEngine-QueueName': 'default'})

--- a/src/util.py
+++ b/src/util.py
@@ -39,6 +39,13 @@ def registry_get(scope, package):
     url = 'https://registry.npmjs.org/%s%s%s' % (scope, '%2f', package)
   return urlfetch.fetch(url, headers=headers, validate_certificate=False)
 
+def unpkg_get(scope, package, version, path):
+  if scope == '@@npm':
+    url = 'https://unpkg.com/%s@%s/%s' % (package, version, path)
+  else:
+    url = 'https://unpkg.com/%s/%s@%s/%s' % (scope, package, version, path)
+  return urlfetch.fetch(url)
+
 def analyze_library_task(owner, repo, latest=False):
   return '/task/analyze/%s/%s/%s' % (owner, repo, latest)
 


### PR DESCRIPTION
In cases where a mono repo is used to publish many packages there are a few assumptions that are no longer true:
 - Versions of packages are not necessarily associated with a particular SHA. NPM registry will no longer return a relevant `gitHead` SHA that can be used.
 - Pulling the GitHub repository readme is no longer correct, since each package typically has its own readme.

This change fixes these two assumptions:
 - It removes the expectation of a SHA for a given NPM version
 - It pulls the readme by looking at the NPM registry metadata for the readme filename, then pulling the readme file contents via unpkg.