### PR TITLE
Use package title when displaying links to packages

### DIFF
--- a/client/src/catalog-item.html
+++ b/client/src/catalog-item.html
@@ -99,7 +99,7 @@
       <a id="container" href="/[[_packagePath(data)]][[_versionPath(data.version, data.default_version)]]">
         <img class="avatar" src="[[data.avatar_url]]&s=[[_dpr(40)]]"   title="[[data.owner]]">
         <div id="header">
-          <h2>[[data.repo]]</h2>
+          <h2>[[_packageTitle(data)]]</h2>
           <div id="description">[[data.description]]</div>
         </div>
         <div id="stats">
@@ -133,6 +133,10 @@
         if (data.npmFullPackage)
           return data.kind + '/' + data.npmFullPackage;
         return [data.kind, data.owner, data.repo].join('/');
+      },
+
+      _packageTitle: function(data) {
+        return data.npmPackage || data.repo;
       },
 
       _versionPath: function(version, latestVersion) {

--- a/client/src/collection-card.html
+++ b/client/src/collection-card.html
@@ -110,7 +110,7 @@
     <template is="dom-if" if="[[data]]">
       <div class="container" type$="[[data.kind]]">
         <a id="header" href="/[[_packagePath(data)]][[_versionPath(data.version, data.default_version)]]" aria-label$="[[data.owner]]/[[data.repo]] collection">
-          <h2>[[data.repo]]</h2>
+          <h2>[[_packageTitle(data)]]</h2>
           <div id="numElements">[[data.dependency_count]] item[[_s(data.dependency_count)]]</div>
           <div id="description">[[data.description]]</div>
         </a>
@@ -157,6 +157,10 @@
         if (data.npmFullPackage)
           return [data.kind, data.npmFullPackage].join('/');
         return [data.kind, data.owner, data.repo].join('/');
+      },
+
+      _packageTitle: function(data) {
+        return data.npmPackage || data.repo;
       },
 
       _computeColor: function(type, owner, repo) {

--- a/src/api.py
+++ b/src/api.py
@@ -100,6 +100,8 @@ class LibraryMetadata(object):
       result['dependency_count'] = metadata['dependency_count']
     if 'npmFullPackage' in metadata:
       result['npmFullPackage'] = metadata['npmFullPackage']
+    if 'npmPackage' in metadata:
+      result['npmPackage'] = metadata['npmPackage']
 
     if not assume_latest:
       result['latest_version'] = metadata['latest_version']


### PR DESCRIPTION
This updates collection cards (used on the homepage) and catalog items (used in lists, such as when displaying search results) to use package titles instead of repo titles. This wasn't picked up earlier since I had only tested with packages which matched the repo they were published with.