### PR TITLE
ES modules support lands in all browsers today!

### DIFF
--- a/client/src/browser-table.html
+++ b/client/src/browser-table.html
@@ -284,7 +284,7 @@
         <a title="Stable" href="https://www.chromestatus.com/feature/5365692190687232"></a>
         <a title="Stable" href="https://www.chromestatus.com/feature/5684934484164608"></a>
         <a title="Stable" href="https://webkit.org/status/#feature-modules"></a>
-        <a title="Developing" href="https://platform-status.mozilla.org/#javascript-modules"></a>
+        <a title="Stable" href="https://platform-status.mozilla.org/#javascript-modules"></a>
         <a title="Stable" href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/moduleses6/"></a>
       </div>
       <div class="row">


### PR DESCRIPTION
Firefox 60 has been released today and has basic support of ES modules (see https://aremodulesready.com and https://aremodulesready.com/test.html for more info).