### PR TITLE
Fix migration from bower

### DIFF
--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -953,7 +953,6 @@ class IngestNPMLibraryTest(ManageTestBase):
     self.assertEqual(library.metadata, '{"owner":{"login":"org"},"name":"repo"}')
     self.assertEqual(library.contributors, '["a"]')
     self.assertEqual(library.tags, ['1.0.0'])
-    self.assertTrue(library.migrated_from_bower)
 
     version = ndb.Key(Library, '@scope/package', Version, '1.0.0').get()
     self.assertIsNotNone(version)
@@ -970,8 +969,9 @@ class IngestNPMLibraryTest(ManageTestBase):
 
     response = self.app.get(util.migrate_library_task('org', 'repo', '@scope', 'package'), headers={'X-AppEngine-QueueName': 'default'})
     self.assertEqual(response.status_int, 200)
-    library = Library.get_by_id('org/repo')
-    self.assertTrue(library.npm_package, '@scope/package')
+    bower_library = Library.get_by_id('org/repo')
+    self.assertTrue(bower_library.npm_package, '@scope/package')
+    self.assertTrue(library.migrated_from_bower)
 
 class UpdateIndexesTest(ManageTestBase):
   def test_update_indexes(self):


### PR DESCRIPTION
There was a bug when publishing a NPM package which always set `migrated_from_bower` to true, which causes a back link to Bower docs to appear. Because this particular function is run inside a transaction, we cannot load the potential Bower library object to check if it exists.

Instead, this change modifies the migration function to update the NPM package to denote that it has been migrated if a Bower package was successfully migrated.