### PR TITLE
HTML IMPORTS (Browser Table)

### DIFF
--- a/client/src/browser-table.html
+++ b/client/src/browser-table.html
@@ -293,18 +293,9 @@
         </a>
         <a title="Stable" href="https://www.chromestatus.com/feature/5144752345317376"></a>
         <a title="Stable" href="https://www.chromestatus.com/feature/5144752345317376"></a>
-        <a href="https://webkit.org/status/#feature-html-imports">
-          <div title="Polyfill"></div>
-          <div title="On hold"></div>
-        </a>
-        <a href="https://platform-status.mozilla.org/#html-imports">
-          <div title="Polyfill"></div>
-          <div title="On hold"></div>
-        </a>
-        <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/htmlimports/">
-          <div title="Polyfill"></div>
-          <div title="Under consideration"></div>
-        </a>
+        <a title="Polyfill" href="https://webkit.org/status/#feature-html-imports"></a>
+        <a title="Polyfill" href="https://platform-status.mozilla.org/#html-imports"></a>
+        <a title="Polyfill" href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/htmlimports/"></a>
       </div>
     </div>
   </template>


### PR DESCRIPTION
Remove the **ON HOLD** and **CONSIDERING** tags from the Browser support table

The tags imply that there is still work to be done but as HTML IMPORTS is being dropped as a way to import web components there's not really any need to look to the future, that being said for legacy reasons it makes sense to keep the row for now.