### PR TITLE
Add `alt` text attributes to the badges in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
   <img alt="webcomponents.org" src="https://web-components-resources.appspot.com/static/logo.svg" width="161">
 </p>
 <p align="center">
-  <a href="https://travis-ci.org/webcomponents/webcomponents.org"><img src="https://img.shields.io/travis/webcomponents/webcomponents.org.svg?style=flat-square"></a>
-  <a href="https://custom-elements-staging.appspot.com"><img src="https://img.shields.io/website/https/custom-elements-staging.appspot.com/index.html.svg?label=staging%20server&amp;style=flat-square"/></a>
-  <a href="https://github.com/webcomponents/webcomponents.org/blob/master/LICENSE"><img src="https://img.shields.io/hexpm/l/plug.svg?maxAge=2592000&style=flat-square"/></a>
-  <a href="https://gitter.im/webcomponents/community"><img src="https://img.shields.io/gitter/room/webcomponents/community.svg?maxAge=2592000&style=flat-square"></a>
+  <a href="https://travis-ci.org/webcomponents/webcomponents.org"><img alt="build" src="https://img.shields.io/travis/webcomponents/webcomponents.org.svg?style=flat-square"></a>
+  <a href="https://custom-elements-staging.appspot.com"><img alt="staging server" src="https://img.shields.io/website/https/custom-elements-staging.appspot.com/index.html.svg?label=staging%20server&amp;style=flat-square"/></a>
+  <a href="https://github.com/webcomponents/webcomponents.org/blob/master/LICENSE"><img alt="license" src="https://img.shields.io/hexpm/l/plug.svg?maxAge=2592000&style=flat-square"/></a>
+  <a href="https://gitter.im/webcomponents/community"><img alt="chat on gitter" src="https://img.shields.io/gitter/room/webcomponents/community.svg?maxAge=2592000&style=flat-square"></a>
 </p>
 
 ## Publishing elements


### PR DESCRIPTION
Some of the badges in the Readme take a while to load, or fail to load at all (especially the build status and staging server badges), this adds the `alt` text attributes to them, so that there’s fallback text in place while the image loads.