### PR TITLE
Bump memory for analysis tasks

### DIFF
--- a/analysis/analysis.yaml
+++ b/analysis/analysis.yaml
@@ -2,6 +2,9 @@ service: analysis
 runtime: nodejs
 env: flex
 threadsafe: false
+resources:
+  cpu: 2
+  memory_gb: 7
 handlers:
 - url: /task/analyze/.*
   script: IGNORED


### PR DESCRIPTION
Large tasks were causing OOMs on minimal resources.