### PR TITLE
Ensure NPM packages appear on GitHub author pages

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -17,6 +17,7 @@ skip_files:
 - client
 - node_modules
 - raw
+- demo
 
 handlers:
 - url: /.*

--- a/client/src/catalog-author.html
+++ b/client/src/catalog-author.html
@@ -59,7 +59,7 @@
       },
 
       _ownerQuery: function(author) {
-        return author && 'owner:' + author;
+        return author ? '(owner:' + author + ' OR github_owner:' + author + ')' : '';
       },
 
       _authorChanged: function(author, visible) {

--- a/manage.yaml
+++ b/manage.yaml
@@ -17,6 +17,7 @@ skip_files:
 - client
 - node_modules
 - raw
+- demo
 
 handlers:
 - url: /.*

--- a/redirect.yaml
+++ b/redirect.yaml
@@ -17,6 +17,7 @@ skip_files:
 - client
 - node_modules
 - raw
+- demo
 
 handlers:
 - url: /service-worker.js

--- a/src/manage.py
+++ b/src/manage.py
@@ -870,6 +870,7 @@ class UpdateIndexes(RequestHandler):
     npm_keywords = registry_metadata.get('keywords', []) if registry_metadata else []
     fields = [
         search.AtomField(name='owner', value=owner),
+        search.AtomField(name='github_owner', value=library.github_owner),
         search.TextField(name='repo', value=repo),
         search.AtomField(name='kind', value=library.kind),
         search.AtomField(name='version', value=version_key.id()),


### PR DESCRIPTION
Fixes #1177.

When NPM support was added, a new field called `github_owner` was added to differentiate between the GitHub repository and the `owner` field which could the scope of the NPM package. This meant that NPM packages could be missed from the queries used to generate author pages. This change adds `github_owner` to search indexes and updates the author queries to use the new field as well.