### PR TITLE
#1218 browser-table updated

### DIFF
--- a/client/src/browser-table.html
+++ b/client/src/browser-table.html
@@ -252,10 +252,7 @@
         <a title="Stable" href="https://www.chromestatus.com/feature/4696261944934400"></a>
         <a title="Stable" href="https://www.chromestatus.com/feature/4696261944934400"></a>
         <a title="Stable" href="https://webkit.org/status/#feature-custom-elements"></a>
-        <a href="https://platform-status.mozilla.org/#custom-elements">
-          <div title="Polyfill"></div>
-          <div title="Developing"></div>
-        </a>
+        <a title="Stable" href="https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/63"></a>
         <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/customelements/">
           <div title="Polyfill"></div>
           <div title="Under consideration"></div>
@@ -268,10 +265,7 @@
         <a title="Stable" href="https://www.chromestatus.com/feature/4667415417847808"></a>
         <a title="Stable" href="https://www.chromestatus.com/feature/4667415417847808"></a>
         <a title="Stable" href="https://webkit.org/status/#feature-shadow-dom"></a>
-        <a href="https://platform-status.mozilla.org/#shadow-dom">
-          <div title="Polyfill"></div>
-          <div title="Developing"></div>
-        </a>
+        <a title="Stable" href="https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/63"></a>
         <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/shadowdom/">
           <div title="Polyfill"></div>
           <div title="Under consideration"></div>
@@ -286,16 +280,6 @@
         <a title="Stable" href="https://webkit.org/status/#feature-modules"></a>
         <a title="Stable" href="https://platform-status.mozilla.org/#javascript-modules"></a>
         <a title="Stable" href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/moduleses6/"></a>
-      </div>
-      <div class="row">
-        <a spec href="https://w3c.github.io/webcomponents/spec/imports/" target="_blank" rel="noopener">
-          <div label="HTML Imports"><svg viewBox="0 0 26 22"><use xlink:href="/sprite.octicons.svg#import"></use></svg></div>
-        </a>
-        <a title="Stable" href="https://www.chromestatus.com/feature/5144752345317376"></a>
-        <a title="Stable" href="https://www.chromestatus.com/feature/5144752345317376"></a>
-        <a title="Polyfill" href="https://webkit.org/status/#feature-html-imports"></a>
-        <a title="Polyfill" href="https://platform-status.mozilla.org/#html-imports"></a>
-        <a title="Polyfill" href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/htmlimports/"></a>
       </div>
     </div>
   </template>


### PR DESCRIPTION
- removes HTML Import from the listing as it is not part of the final path way to web components
- updates Firefox details to suggest it is now stable in ShadowDOM and Custom Element specs