### PR TITLE
Add site dev server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,55 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@apollo/client": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.7.0.tgz",
+      "integrity": "sha512-hp4OvrH1ZIQACRYcIrh/C0WFnY7IM7G6nlTpC8DSTEWxfZQ2kvpvDY0I/hYmCs0oAVrg26g3ANEdOzGWTcYbPg==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/context": "^0.7.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.3.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.1",
+        "prop-types": "^15.7.2",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apollo/client/node_modules/symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/@ardatan/relay-compiler": {
       "version": "12.0.0",
       "dev": true,
@@ -1090,8 +1139,9 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -1824,6 +1874,76 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/@graphql-codegen/cli/node_modules/cosmiconfig-typescript-loader": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.1.tgz",
+      "integrity": "sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=7",
+        "ts-node": ">=10",
+        "typescript": ">=3"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@graphql-codegen/cli/node_modules/yargs": {
       "version": "17.5.1",
       "dev": true,
@@ -2382,6 +2502,14 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.6.12",
       "license": "Apache-2.0",
@@ -2845,23 +2973,27 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
     },
     "node_modules/@types/accepts": {
       "version": "1.3.5",
@@ -3203,6 +3335,25 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.38.1",
       "license": "BSD-2-Clause",
@@ -3268,6 +3419,25 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/type-utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
       "version": "5.38.1",
       "license": "MIT",
@@ -3302,6 +3472,25 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -3353,7 +3542,8 @@
     },
     "node_modules/@web/dev-server": {
       "version": "0.1.34",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.1.34.tgz",
+      "integrity": "sha512-+te6iwxAQign1KyhHpkR/a3+5qw/Obg/XWCES2So6G5LcZ86zIKXbUpWAJuNOqiBV6eGwqEB1AozKr2Jj7gj/Q==",
       "dependencies": {
         "@babel/code-frame": "^7.12.11",
         "@types/command-line-args": "^5.0.0",
@@ -3565,6 +3755,39 @@
         }
       }
     },
+    "node_modules/@wry/context": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.0.tgz",
+      "integrity": "sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.3.tgz",
+      "integrity": "sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
+      "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "license": "MIT"
@@ -3613,8 +3836,9 @@
     },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3713,8 +3937,9 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4860,8 +5085,8 @@
     },
     "node_modules/compressible": {
       "version": "2.0.18",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mime-db": ">= 1.43.0 < 2"
       },
@@ -5056,25 +5281,11 @@
         "@iarna/toml": "^2.2.5"
       }
     },
-    "node_modules/cosmiconfig-typescript-loader": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "cosmiconfig": ">=7",
-        "ts-node": ">=10",
-        "typescript": ">=3"
-      }
-    },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -6893,12 +7104,6 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/firebase-tools/node_modules/@gar/promisify": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/firebase-tools/node_modules/@google-cloud/precise-date": {
       "version": "2.0.3",
       "dev": true,
@@ -6960,40 +7165,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/firebase-tools/node_modules/@google-cloud/pubsub/node_modules/@grpc/proto-loader": {
-      "version": "0.6.12",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/long": "^4.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/@google-cloud/pubsub/node_modules/debug": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/firebase-tools/node_modules/@google-cloud/pubsub/node_modules/gaxios": {
       "version": "5.0.0",
       "dev": true,
@@ -7040,32 +7211,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/firebase-tools/node_modules/@google-cloud/pubsub/node_modules/google-gax": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grpc/grpc-js": "~1.6.0",
-        "@grpc/proto-loader": "^0.6.12",
-        "@types/long": "^4.0.0",
-        "abort-controller": "^3.0.0",
-        "duplexify": "^4.0.0",
-        "fast-text-encoding": "^1.0.3",
-        "google-auth-library": "^8.0.2",
-        "is-stream-ended": "^0.1.4",
-        "node-fetch": "^2.6.1",
-        "object-hash": "^3.0.0",
-        "proto3-json-serializer": "^1.0.0",
-        "protobufjs": "6.11.3",
-        "retry-request": "^5.0.0"
-      },
-      "bin": {
-        "compileProtos": "build/tools/compileProtos.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/firebase-tools/node_modules/@google-cloud/pubsub/node_modules/is-stream": {
       "version": "2.0.1",
       "dev": true,
@@ -7094,64 +7239,6 @@
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/@google-cloud/pubsub/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/@google-cloud/pubsub/node_modules/proto3-json-serializer": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "protobufjs": "^6.11.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/@google-cloud/pubsub/node_modules/retry-request": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "extend": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/@grpc/grpc-js": {
-      "version": "1.6.7",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grpc/proto-loader": "^0.6.4",
-        "@types/node": ">=12.12.47"
-      },
-      "engines": {
-        "node": "^8.13.0 || >=10.10.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
-      "version": "0.6.9",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/long": "^4.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/firebase-tools/node_modules/@jsdevtools/ono": {
@@ -7228,60 +7315,6 @@
         "node": ">=8.12.0"
       }
     },
-    "node_modules/firebase-tools/node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/firebase-tools/node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/firebase-tools/node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/firebase-tools/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/firebase-tools/node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/firebase-tools/node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/firebase-tools/node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/firebase-tools/node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/firebase-tools/node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/firebase-tools/node_modules/@sindresorhus/is": {
       "version": "0.14.0",
       "dev": true,
@@ -7308,11 +7341,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/firebase-tools/node_modules/@types/color-name": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/firebase-tools/node_modules/@types/duplexify": {
       "version": "3.6.0",
@@ -7430,19 +7458,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/firebase-tools/node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/firebase-tools/node_modules/ajv-formats": {
       "version": "2.1.1",
       "dev": true,
@@ -7524,18 +7539,6 @@
       "version": "0.3.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/anymatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/firebase-tools/node_modules/aproba": {
       "version": "2.0.0",
@@ -7625,14 +7628,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/firebase-tools/node_modules/arrify": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/firebase-tools/node_modules/as-array": {
       "version": "2.0.0",
       "dev": true,
@@ -7665,11 +7660,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/firebase-tools/node_modules/ast-types/node_modules/tslib": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/firebase-tools/node_modules/async": {
       "version": "2.6.4",
       "dev": true,
@@ -7683,11 +7673,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/firebase-tools/node_modules/asynckit": {
-      "version": "0.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/aws-sign2": {
       "version": "0.7.0",
       "dev": true,
@@ -7698,16 +7683,6 @@
     },
     "node_modules/firebase-tools/node_modules/aws4": {
       "version": "1.8.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/balanced-match": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/base64-js": {
-      "version": "1.3.0",
       "dev": true,
       "license": "MIT"
     },
@@ -7743,14 +7718,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/firebase-tools/node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/firebase-tools/node_modules/binary": {
       "version": "0.3.0",
       "dev": true,
@@ -7758,24 +7725,6 @@
       "dependencies": {
         "buffers": "~0.1.1",
         "chainsaw": "~0.1.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/binary-extensions": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/bl": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/firebase-tools/node_modules/bluebird": {
@@ -7824,21 +7773,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/firebase-tools/node_modules/boxen/node_modules/ansi-styles": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/color-name": "^1.1.1",
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/firebase-tools/node_modules/boxen/node_modules/chalk": {
       "version": "3.0.0",
       "dev": true,
@@ -7846,41 +7780,6 @@
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/boxen/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/boxen/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/boxen/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/boxen/node_modules/supports-color": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -7895,40 +7794,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/firebase-tools/node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/buffer": {
-      "version": "5.7.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/firebase-tools/node_modules/buffer-crc32": {
       "version": "0.2.13",
       "dev": true,
@@ -7937,11 +7802,6 @@
         "node": "*"
       }
     },
-    "node_modules/firebase-tools/node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/firebase-tools/node_modules/buffer-indexof-polyfill": {
       "version": "1.0.1",
       "dev": true,
@@ -7949,25 +7809,6 @@
       "engines": {
         "node": ">=0.10"
       }
-    },
-    "node_modules/firebase-tools/node_modules/buffer/node_modules/base64-js": {
-      "version": "1.5.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/firebase-tools/node_modules/buffers": {
       "version": "0.1.1",
@@ -8013,15 +7854,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/firebase-tools/node_modules/cacache/node_modules/chownr": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/firebase-tools/node_modules/cacache/node_modules/mkdirp": {
       "version": "1.0.4",
       "dev": true,
@@ -8032,21 +7864,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/cacache/node_modules/p-map": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/firebase-tools/node_modules/cacheable-request": {
@@ -8085,14 +7902,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/firebase-tools/node_modules/camelcase": {
-      "version": "5.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/firebase-tools/node_modules/cardinal": {
       "version": "2.1.1",
       "dev": true,
@@ -8118,37 +7927,6 @@
         "traverse": ">=0.3.0 <0.4"
       }
     },
-    "node_modules/firebase-tools/node_modules/chardet": {
-      "version": "0.7.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/chokidar": {
-      "version": "3.5.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/firebase-tools/node_modules/ci-info": {
       "version": "2.0.0",
       "dev": true,
@@ -8165,39 +7943,8 @@
         "node": ">= 0.3.0"
       }
     },
-    "node_modules/firebase-tools/node_modules/clean-stack": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/firebase-tools/node_modules/cli-boxes": {
       "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/cli-spinners": {
-      "version": "2.6.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8229,32 +7976,6 @@
       },
       "optionalDependencies": {
         "@colors/colors": "1.5.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/cli-width": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/cliui": {
-      "version": "7.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/clone": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/firebase-tools/node_modules/clone-response": {
@@ -8305,11 +8026,6 @@
         "color-support": "bin.js"
       }
     },
-    "node_modules/firebase-tools/node_modules/colorette": {
-      "version": "2.0.19",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/colornames": {
       "version": "1.1.1",
       "dev": true,
@@ -8330,17 +8046,6 @@
       "dependencies": {
         "color": "3.0.x",
         "text-hex": "1.0.x"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/combined-stream": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/firebase-tools/node_modules/commander": {
@@ -8373,17 +8078,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/firebase-tools/node_modules/compressible": {
-      "version": "2.0.17",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": ">= 1.40.0 < 2"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/firebase-tools/node_modules/compression": {
       "version": "1.7.4",
       "dev": true,
@@ -8408,11 +8102,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/firebase-tools/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/firebase-tools/node_modules/configstore": {
       "version": "5.0.1",
@@ -8499,14 +8188,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/firebase-tools/node_modules/content-type": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/firebase-tools/node_modules/cookie": {
       "version": "0.4.0",
       "dev": true,
@@ -8524,18 +8205,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/cors": {
-      "version": "2.8.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/firebase-tools/node_modules/crc-32": {
       "version": "1.2.0",
@@ -8595,60 +8264,6 @@
         "node": ">=4.8"
       }
     },
-    "node_modules/firebase-tools/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/cross-spawn/node_modules/path-key": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/cross-spawn/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/cross-spawn/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/cross-spawn/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/firebase-tools/node_modules/csv-parse": {
       "version": "5.0.4",
       "dev": true,
@@ -8692,31 +8307,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/firebase-tools/node_modules/deep-extend": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/deep-freeze": {
       "version": "0.0.1",
       "dev": true,
       "license": "public domain"
-    },
-    "node_modules/firebase-tools/node_modules/deep-is": {
-      "version": "0.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/defaults": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      }
     },
     "node_modules/firebase-tools/node_modules/defer-to-connect": {
       "version": "1.1.3",
@@ -8736,20 +8330,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/firebase-tools/node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/delegates": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/firebase-tools/node_modules/depd": {
       "version": "1.1.2",
@@ -8801,17 +8381,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/firebase-tools/node_modules/duplexify": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "dev": true,
@@ -8821,67 +8390,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "node_modules/firebase-tools/node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/ee-first": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/enabled": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "env-variable": "0.0.x"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/end-of-stream": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/firebase-tools/node_modules/env-paths": {
@@ -8898,20 +8412,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/firebase-tools/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/firebase-tools/node_modules/escalade": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/firebase-tools/node_modules/escape-goat": {
       "version": "2.1.1",
       "dev": true,
@@ -8920,90 +8420,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/firebase-tools/node_modules/escape-html": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/escodegen": {
-      "version": "1.14.3",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/esprima": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/estraverse": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/esutils": {
-      "version": "2.0.2",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/etag": {
-      "version": "1.8.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/firebase-tools/node_modules/events-listener": {
@@ -9133,35 +8555,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/firebase-tools/node_modules/extend": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/external-editor": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/extsprintf": {
       "version": "1.3.0",
       "dev": true,
@@ -9170,25 +8563,10 @@
       ],
       "license": "MIT"
     },
-    "node_modules/firebase-tools/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/fast-text-encoding": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/firebase-tools/node_modules/fast-url-parser": {
       "version": "1.1.3",
@@ -9208,20 +8586,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/firebase-tools/node_modules/figures": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/firebase-tools/node_modules/file-uri-to-path": {
       "version": "2.0.0",
       "dev": true,
@@ -9236,17 +8600,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/firebase-tools/node_modules/finalhandler": {
@@ -9291,11 +8644,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/firebase-tools/node_modules/firebase-frameworks/node_modules/tslib": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/firebase-tools/node_modules/forever-agent": {
       "version": "0.6.1",
       "dev": true,
@@ -9319,14 +8667,6 @@
     },
     "node_modules/firebase-tools/node_modules/forwarded": {
       "version": "0.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/fresh": {
-      "version": "0.5.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9368,34 +8708,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/firebase-tools/node_modules/fsevents": {
-      "version": "2.3.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/fstream": {
@@ -9542,14 +8854,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/firebase-tools/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/firebase-tools/node_modules/get-stream": {
       "version": "4.1.0",
       "dev": true,
@@ -9638,17 +8942,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/firebase-tools/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/firebase-tools/node_modules/glob-slash": {
       "version": "1.0.0",
       "dev": true,
@@ -9725,14 +9018,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/google-p12-pem/node_modules/node-forge": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
       }
     },
     "node_modules/firebase-tools/node_modules/googleapis": {
@@ -9879,14 +9164,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/firebase-tools/node_modules/googleapis-common/node_modules/node-forge": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/googleapis/node_modules/gaxios": {
       "version": "5.0.1",
       "dev": true,
@@ -10004,14 +9281,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/firebase-tools/node_modules/googleapis/node_modules/node-forge": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/got": {
       "version": "9.6.0",
       "dev": true,
@@ -10032,11 +9301,6 @@
       "engines": {
         "node": ">=8.6"
       }
-    },
-    "node_modules/firebase-tools/node_modules/graceful-fs": {
-      "version": "4.2.9",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/firebase-tools/node_modules/gtoken": {
       "version": "5.3.2",
@@ -10090,17 +9354,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/firebase-tools/node_modules/has-ansi": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/has-unicode": {
       "version": "2.0.1",
       "dev": true,
@@ -10114,11 +9367,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/firebase-tools/node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause"
     },
     "node_modules/firebase-tools/node_modules/http-errors": {
       "version": "1.7.2",
@@ -10188,40 +9436,6 @@
         "npm": ">=1.3.7"
       }
     },
-    "node_modules/firebase-tools/node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/iconv-lite": {
       "version": "0.4.24",
       "dev": true,
@@ -10233,186 +9447,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/firebase-tools/node_modules/ieee754": {
-      "version": "1.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/firebase-tools/node_modules/import-lazy": {
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/indent-string": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/infer-owner": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/firebase-tools/node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/firebase-tools/node_modules/ini": {
-      "version": "1.3.8",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/firebase-tools/node_modules/inquirer": {
-      "version": "8.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.1",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "0.0.8",
-        "ora": "^5.4.1",
-        "run-async": "^2.4.0",
-        "rxjs": "^7.2.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/inquirer/node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/inquirer/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/inquirer/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/inquirer/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/inquirer/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/inquirer/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/inquirer/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/inquirer/node_modules/type-fest": {
-      "version": "0.21.3",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/firebase-tools/node_modules/install-artifact-from-github": {
@@ -10446,17 +9486,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/firebase-tools/node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/firebase-tools/node_modules/is-ci": {
       "version": "2.0.0",
       "dev": true,
@@ -10466,33 +9495,6 @@
       },
       "bin": {
         "is-ci": "bin.js"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/is-extglob": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/is-glob": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/firebase-tools/node_modules/is-installed-globally": {
@@ -10510,34 +9512,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/firebase-tools/node_modules/is-interactive": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/is-lambda": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/firebase-tools/node_modules/is-npm": {
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/firebase-tools/node_modules/is-path-inside": {
@@ -10556,39 +9536,15 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/firebase-tools/node_modules/is-stream-ended": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/is-typedarray": {
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/firebase-tools/node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/firebase-tools/node_modules/is-url": {
       "version": "1.2.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/is-windows": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/firebase-tools/node_modules/is-wsl": {
       "version": "1.1.0",
@@ -10615,16 +9571,6 @@
       "engines": {
         "node": ">=v0.10.0"
       }
-    },
-    "node_modules/firebase-tools/node_modules/isarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/isexe": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/firebase-tools/node_modules/isstream": {
       "version": "0.1.2",
@@ -10663,14 +9609,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/firebase-tools/node_modules/json-bigint": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/json-buffer": {
       "version": "3.0.0",
       "dev": true,
@@ -10699,11 +9637,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/firebase-tools/node_modules/jsonc-parser": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/jsonfile": {
       "version": "4.0.0",
       "dev": true,
@@ -10711,32 +9644,6 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
-    },
-    "node_modules/firebase-tools/node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/jsonwebtoken/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/firebase-tools/node_modules/jsprim": {
       "version": "1.4.2",
@@ -10750,25 +9657,6 @@
       },
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/jwa": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/jws": {
-      "version": "3.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/firebase-tools/node_modules/keyv": {
@@ -10823,18 +9711,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/firebase-tools/node_modules/levn": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/libsodium": {
       "version": "0.7.10",
       "dev": true,
@@ -10853,18 +9729,8 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/firebase-tools/node_modules/lodash": {
-      "version": "4.17.21",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/lodash._objecttypes": {
       "version": "2.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/lodash.camelcase": {
-      "version": "4.3.0",
       "dev": true,
       "license": "MIT"
     },
@@ -10883,26 +9749,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/firebase-tools/node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/lodash.isobject": {
       "version": "2.4.1",
       "dev": true,
@@ -10910,21 +9756,6 @@
       "dependencies": {
         "lodash._objecttypes": "~2.4.1"
       }
-    },
-    "node_modules/firebase-tools/node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/lodash.once": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/firebase-tools/node_modules/lodash.snakecase": {
       "version": "4.1.1",
@@ -10935,85 +9766,6 @@
       "version": "4.6.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/log-symbols": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/log-symbols/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/log-symbols/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/log-symbols/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/log-symbols/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/log-symbols/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/firebase-tools/node_modules/logform": {
       "version": "2.1.2",
@@ -11040,28 +9792,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/firebase-tools/node_modules/long": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/firebase-tools/node_modules/lowercase-keys": {
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/firebase-tools/node_modules/make-dir": {
@@ -11150,17 +9886,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/firebase-tools/node_modules/marked": {
-      "version": "4.0.14",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/firebase-tools/node_modules/marked-terminal": {
       "version": "5.1.1",
       "dev": true,
@@ -11191,14 +9916,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/firebase-tools/node_modules/media-typer": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/firebase-tools/node_modules/merge-descriptors": {
       "version": "1.0.1",
       "dev": true,
@@ -11213,33 +9930,6 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/mime-db": {
-      "version": "1.40.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/mime-types": {
-      "version": "2.1.24",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.40.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/firebase-tools/node_modules/mimic-response": {
@@ -11261,34 +9951,6 @@
         "node": "*"
       }
     },
-    "node_modules/firebase-tools/node_modules/minimist": {
-      "version": "1.2.6",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/minipass": {
-      "version": "3.1.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/firebase-tools/node_modules/minipass-fetch": {
       "version": "1.4.1",
       "dev": true,
@@ -11304,54 +9966,6 @@
       },
       "optionalDependencies": {
         "encoding": "^0.1.12"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/minizlib": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/firebase-tools/node_modules/mkdirp": {
@@ -11393,24 +10007,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/firebase-tools/node_modules/mute-stream": {
-      "version": "0.0.8",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/firebase-tools/node_modules/nan": {
       "version": "2.15.0",
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/firebase-tools/node_modules/negotiator": {
-      "version": "0.6.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/firebase-tools/node_modules/netmask": {
       "version": "2.0.2",
@@ -11521,14 +10122,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/firebase-tools/node_modules/normalize-path": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/normalize-url": {
       "version": "4.5.1",
       "dev": true,
@@ -11560,33 +10153,6 @@
         "node": "*"
       }
     },
-    "node_modules/firebase-tools/node_modules/object-assign": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/object-hash": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/on-finished": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/firebase-tools/node_modules/on-headers": {
       "version": "1.0.2",
       "dev": true,
@@ -11595,32 +10161,10 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/firebase-tools/node_modules/once": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/firebase-tools/node_modules/one-time": {
       "version": "0.0.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/onetime": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/firebase-tools/node_modules/open": {
       "version": "6.4.0",
@@ -11639,116 +10183,6 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^1.10.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/optionator": {
-      "version": "0.8.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/ora": {
-      "version": "5.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/ora/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/ora/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/ora/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/ora/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/ora/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/ora/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/firebase-tools/node_modules/p-cancelable": {
@@ -11842,22 +10276,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/firebase-tools/node_modules/parseurl": {
-      "version": "1.3.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/path-key": {
       "version": "2.0.1",
       "dev": true,
@@ -11875,50 +10293,6 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/picomatch": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/portfinder": {
-      "version": "1.0.28",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async": "^2.6.2",
-        "debug": "^3.1.1",
-        "mkdirp": "^0.5.5"
-      },
-      "engines": {
-        "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/portfinder/node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/portfinder/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
     },
     "node_modules/firebase-tools/node_modules/prepend-http": {
       "version": "2.0.0",
@@ -11939,11 +10313,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/firebase-tools/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/progress": {
       "version": "2.0.3",
       "dev": true,
@@ -11954,64 +10323,6 @@
     },
     "node_modules/firebase-tools/node_modules/promise-breaker": {
       "version": "5.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/firebase-tools/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/promise-retry/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/protobufjs": {
-      "version": "6.11.3",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/protobufjs/node_modules/@types/node": {
-      "version": "17.0.8",
       "dev": true,
       "license": "MIT"
     },
@@ -12098,14 +10409,6 @@
         "once": "^1.3.1"
       }
     },
-    "node_modules/firebase-tools/node_modules/punycode": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/firebase-tools/node_modules/pupa": {
       "version": "2.1.1",
       "dev": true,
@@ -12123,14 +10426,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/range-parser": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/firebase-tools/node_modules/raw-body": {
@@ -12173,36 +10468,12 @@
         "node-gyp": "^8.4.1"
       }
     },
-    "node_modules/firebase-tools/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/firebase-tools/node_modules/readdir-glob": {
       "version": "1.1.1",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^3.0.4"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/readdirp": {
-      "version": "3.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/firebase-tools/node_modules/redeyed": {
@@ -12294,14 +10565,6 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/firebase-tools/node_modules/require-directory": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/require-from-string": {
       "version": "2.0.2",
       "dev": true,
@@ -12318,38 +10581,12 @@
         "lowercase-keys": "^1.0.0"
       }
     },
-    "node_modules/firebase-tools/node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/firebase-tools/node_modules/retry": {
       "version": "0.13.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/rimraf": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/firebase-tools/node_modules/router": {
@@ -12378,37 +10615,6 @@
       "version": "1.2.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/firebase-tools/node_modules/run-async": {
-      "version": "2.4.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/rxjs": {
-      "version": "7.5.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/rxjs/node_modules/tslib": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/firebase-tools/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/firebase-tools/node_modules/semver": {
       "version": "5.7.1",
@@ -12490,17 +10696,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/firebase-tools/node_modules/set-blocking": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/firebase-tools/node_modules/setimmediate": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/setprototypeof": {
       "version": "1.1.1",
       "dev": true,
@@ -12525,11 +10720,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/firebase-tools/node_modules/signal-exit": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/firebase-tools/node_modules/simple-swizzle": {
       "version": "0.2.2",
       "dev": true,
@@ -12542,28 +10732,6 @@
       "version": "0.3.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/socks": {
-      "version": "2.6.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 3.0.0"
-      }
     },
     "node_modules/firebase-tools/node_modules/socks-proxy-agent": {
       "version": "5.0.1",
@@ -12598,11 +10766,6 @@
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/firebase-tools/node_modules/sshpk": {
       "version": "1.16.1",
@@ -12669,19 +10832,6 @@
         "stream-chain": "^2.2.4"
       }
     },
-    "node_modules/firebase-tools/node_modules/stream-shift": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/string-length": {
       "version": "1.0.1",
       "dev": true,
@@ -12702,38 +10852,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/firebase-tools/node_modules/strip-json-comments": {
@@ -12826,14 +10944,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/superstatic/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/firebase-tools/node_modules/superstatic/node_modules/isarray": {
@@ -12943,41 +11053,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/firebase-tools/node_modules/supports-hyperlinks/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/supports-hyperlinks/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/tar": {
-      "version": "6.1.11",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/firebase-tools/node_modules/tar-stream": {
       "version": "2.2.0",
       "dev": true,
@@ -12991,25 +11066,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/tar/node_modules/chownr": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/tar/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/firebase-tools/node_modules/tcp-port-used": {
@@ -13058,39 +11114,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/firebase-tools/node_modules/through": {
-      "version": "2.3.8",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/tmp": {
-      "version": "0.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.17.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/to-readable-stream": {
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/firebase-tools/node_modules/toidentifier": {
@@ -13121,11 +11150,6 @@
         "lodash": "^4.17.10"
       }
     },
-    "node_modules/firebase-tools/node_modules/tr46": {
-      "version": "0.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/traverse": {
       "version": "0.3.9",
       "dev": true,
@@ -13152,35 +11176,12 @@
       "dev": true,
       "license": "Unlicense"
     },
-    "node_modules/firebase-tools/node_modules/type-check": {
-      "version": "0.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/firebase-tools/node_modules/type-fest": {
       "version": "0.8.1",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/type-is": {
-      "version": "1.6.18",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/firebase-tools/node_modules/typedarray-to-buffer": {
@@ -13242,22 +11243,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/firebase-tools/node_modules/universalify": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/unpipe": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/firebase-tools/node_modules/unzipper": {
       "version": "0.10.10",
       "dev": true,
@@ -13316,20 +11301,6 @@
         "url": "https://github.com/yeoman/update-notifier?sponsor=1"
       }
     },
-    "node_modules/firebase-tools/node_modules/update-notifier/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/firebase-tools/node_modules/update-notifier/node_modules/boxen": {
       "version": "5.1.2",
       "dev": true,
@@ -13362,37 +11333,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/firebase-tools/node_modules/update-notifier/node_modules/chalk": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/update-notifier/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/update-notifier/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/firebase-tools/node_modules/update-notifier/node_modules/global-dirs": {
       "version": "3.0.0",
       "dev": true,
@@ -13405,14 +11345,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/update-notifier/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/firebase-tools/node_modules/update-notifier/node_modules/ini": {
@@ -13463,17 +11395,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/firebase-tools/node_modules/update-notifier/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/firebase-tools/node_modules/update-notifier/node_modules/type-fest": {
       "version": "0.20.2",
       "dev": true,
@@ -13506,38 +11427,9 @@
       "dev": true,
       "license": "BSD"
     },
-    "node_modules/firebase-tools/node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/utils-merge": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/uuid": {
-      "version": "8.3.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/firebase-tools/node_modules/valid-url": {
       "version": "1.0.9",
       "dev": true
-    },
-    "node_modules/firebase-tools/node_modules/vary": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/firebase-tools/node_modules/verror": {
       "version": "1.10.0",
@@ -13550,14 +11442,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/wcwidth": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
       }
     },
     "node_modules/firebase-tools/node_modules/webidl-conversions": {
@@ -13650,65 +11534,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/firebase-tools/node_modules/word-wrap": {
-      "version": "1.2.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/wrappy": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/firebase-tools/node_modules/write-file-atomic": {
       "version": "3.0.3",
       "dev": true,
@@ -13752,52 +11577,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/firebase-tools/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/firebase-tools/node_modules/yaml": {
-      "version": "1.10.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/yargs": {
-      "version": "16.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/yargs/node_modules/y18n": {
-      "version": "5.0.8",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/firebase-tools/node_modules/zip-stream": {
       "version": "4.0.4",
@@ -14282,6 +12061,31 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/graphql-config/node_modules/cosmiconfig-typescript-loader": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.1.tgz",
+      "integrity": "sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=7",
+        "ts-node": ">=10",
+        "typescript": ">=3"
+      }
+    },
+    "node_modules/graphql-config/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/graphql-config/node_modules/minimatch": {
       "version": "4.2.1",
       "dev": true,
@@ -14291,6 +12095,49 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/graphql-config/node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/graphql-helix": {
@@ -14327,7 +12174,6 @@
     },
     "node_modules/graphql-tag": {
       "version": "2.12.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -14341,7 +12187,7 @@
     },
     "node_modules/graphql-ws": {
       "version": "5.10.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -14549,6 +12395,14 @@
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -16283,7 +14137,6 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -16347,8 +14200,9 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/make-fetch-happen": {
       "version": "10.2.1",
@@ -17168,6 +15022,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/optimism": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "dependencies": {
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
+      }
+    },
+    "node_modules/optimism/node_modules/@wry/context": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
+      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.8.3",
       "license": "MIT",
@@ -17572,6 +15446,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "license": "MIT",
@@ -17853,6 +15737,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/readable-stream": {
       "version": "3.6.0",
@@ -18197,6 +16086,14 @@
     "node_modules/resp-modifier/node_modules/ms": {
       "version": "2.0.0",
       "license": "MIT"
+    },
+    "node_modules/response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
@@ -19505,60 +17402,21 @@
       "version": "0.0.3",
       "license": "MIT"
     },
+    "node_modules/ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ts-log": {
       "version": "2.2.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/ts-simple-type": {
       "version": "1.0.7",
@@ -19595,23 +17453,6 @@
         "node": ">=0.6.x"
       }
     },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "node_modules/tsutils/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
-    },
     "node_modules/type-check": {
       "version": "0.3.2",
       "license": "MIT",
@@ -19645,8 +17486,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "license": "Apache-2.0",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19932,8 +17774,9 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/validate-npm-package-name": {
       "version": "4.0.0",
@@ -20360,8 +18203,9 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -20374,6 +18218,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "dependencies": {
+        "zen-observable": "0.8.15"
       }
     },
     "packages/catalog-api": {
@@ -20457,10 +18314,12 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@apollo/client": "^3.7.0",
         "@types/koa": "^2.13.5",
         "@types/koa-conditional-get": "^2.0.0",
         "@types/koa-etag": "^3.0.0",
         "@types/koa-static": "^4.0.2",
+        "@web/dev-server": "^0.1.34",
         "koa": "^2.13.4",
         "koa-conditional-get": "^3.0.0",
         "koa-etag": "^4.0.0",
@@ -20532,6 +18391,33 @@
             "@jridgewell/set-array": "^1.0.0",
             "@jridgewell/sourcemap-codec": "^1.4.10"
           }
+        }
+      }
+    },
+    "@apollo/client": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.7.0.tgz",
+      "integrity": "sha512-hp4OvrH1ZIQACRYcIrh/C0WFnY7IM7G6nlTpC8DSTEWxfZQ2kvpvDY0I/hYmCs0oAVrg26g3ANEdOzGWTcYbPg==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/context": "^0.7.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.3.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.1",
+        "prop-types": "^15.7.2",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+          "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
         }
       }
     },
@@ -21136,6 +19022,8 @@
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -21638,6 +19526,42 @@
         "yargs": "^17.0.0"
       },
       "dependencies": {
+        "cosmiconfig-typescript-loader": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.1.tgz",
+          "integrity": "sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==",
+          "dev": true,
+          "requires": {}
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true,
+          "peer": true
+        },
+        "ts-node": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+          "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@cspotcode/source-map-support": "^0.8.0",
+            "@tsconfig/node10": "^1.0.7",
+            "@tsconfig/node12": "^1.0.7",
+            "@tsconfig/node14": "^1.0.0",
+            "@tsconfig/node16": "^1.0.2",
+            "acorn": "^8.4.1",
+            "acorn-walk": "^8.1.1",
+            "arg": "^4.1.0",
+            "create-require": "^1.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "v8-compile-cache-lib": "^3.0.1",
+            "yn": "3.1.1"
+          }
+        },
         "yargs": {
           "version": "17.5.1",
           "dev": true,
@@ -22054,6 +19978,12 @@
         }
       }
     },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "requires": {}
+    },
     "@grpc/grpc-js": {
       "version": "1.6.12",
       "requires": {
@@ -22362,18 +20292,26 @@
     },
     "@tsconfig/node10": {
       "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
       "dev": true
     },
     "@tsconfig/node12": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true
     },
     "@tsconfig/node14": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
     "@tsconfig/node16": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "@types/accepts": {
@@ -22649,6 +20587,21 @@
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
       }
     },
     "@typescript-eslint/parser": {
@@ -22674,6 +20627,21 @@
         "@typescript-eslint/utils": "5.38.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
       }
     },
     "@typescript-eslint/types": {
@@ -22689,6 +20657,21 @@
         "is-glob": "^4.0.3",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
       }
     },
     "@typescript-eslint/utils": {
@@ -22717,6 +20700,8 @@
     },
     "@web/dev-server": {
       "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.1.34.tgz",
+      "integrity": "sha512-+te6iwxAQign1KyhHpkR/a3+5qw/Obg/XWCES2So6G5LcZ86zIKXbUpWAJuNOqiBV6eGwqEB1AozKr2Jj7gj/Q==",
       "requires": {
         "@babel/code-frame": "^7.12.11",
         "@types/command-line-args": "^5.0.0",
@@ -22879,10 +20864,12 @@
     "@webcomponents/internal-site-server": {
       "version": "file:packages/site-server",
       "requires": {
+        "@apollo/client": "^3.7.0",
         "@types/koa": "^2.13.5",
         "@types/koa-conditional-get": "^2.0.0",
         "@types/koa-etag": "^3.0.0",
         "@types/koa-static": "^4.0.2",
+        "@web/dev-server": "^0.1.34",
         "koa": "^2.13.4",
         "koa-conditional-get": "^3.0.0",
         "koa-etag": "^4.0.0",
@@ -22913,6 +20900,30 @@
         }
       }
     },
+    "@wry/context": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.0.tgz",
+      "integrity": "sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.3.tgz",
+      "integrity": "sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@wry/trie": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
+      "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
     "a-sync-waterfall": {
       "version": "1.0.1"
     },
@@ -22941,6 +20952,8 @@
     },
     "acorn-walk": {
       "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
     "agent-base": {
@@ -22998,6 +21011,8 @@
     },
     "arg": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "argparse": {
@@ -23726,7 +21741,7 @@
     },
     "compressible": {
       "version": "2.0.18",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "mime-db": ">= 1.43.0 < 2"
       }
@@ -23860,13 +21875,10 @@
         "@iarna/toml": "^2.2.5"
       }
     },
-    "cosmiconfig-typescript-loader": {
-      "version": "4.0.0",
-      "dev": true,
-      "requires": {}
-    },
     "create-require": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "cross-fetch": {
@@ -25067,11 +23079,6 @@
           "dev": true,
           "optional": true
         },
-        "@gar/promisify": {
-          "version": "1.1.2",
-          "dev": true,
-          "optional": true
-        },
         "@google-cloud/precise-date": {
           "version": "2.0.3",
           "dev": true
@@ -25113,24 +23120,6 @@
                 "extend": "^3.0.2"
               }
             },
-            "@grpc/proto-loader": {
-              "version": "0.6.12",
-              "dev": true,
-              "requires": {
-                "@types/long": "^4.0.1",
-                "lodash.camelcase": "^4.3.0",
-                "long": "^4.0.0",
-                "protobufjs": "^6.10.0",
-                "yargs": "^16.2.0"
-              }
-            },
-            "debug": {
-              "version": "4.3.4",
-              "dev": true,
-              "requires": {
-                "ms": "2.1.2"
-              }
-            },
             "gaxios": {
               "version": "5.0.0",
               "dev": true,
@@ -25165,25 +23154,6 @@
                 "lru-cache": "^6.0.0"
               }
             },
-            "google-gax": {
-              "version": "3.0.3",
-              "dev": true,
-              "requires": {
-                "@grpc/grpc-js": "~1.6.0",
-                "@grpc/proto-loader": "^0.6.12",
-                "@types/long": "^4.0.0",
-                "abort-controller": "^3.0.0",
-                "duplexify": "^4.0.0",
-                "fast-text-encoding": "^1.0.3",
-                "google-auth-library": "^8.0.2",
-                "is-stream-ended": "^0.1.4",
-                "node-fetch": "^2.6.1",
-                "object-hash": "^3.0.0",
-                "proto3-json-serializer": "^1.0.0",
-                "protobufjs": "6.11.3",
-                "retry-request": "^5.0.0"
-              }
-            },
             "is-stream": {
               "version": "2.0.1",
               "dev": true
@@ -25203,46 +23173,6 @@
               "requires": {
                 "jwa": "^2.0.0",
                 "safe-buffer": "^5.0.1"
-              }
-            },
-            "ms": {
-              "version": "2.1.2",
-              "dev": true
-            },
-            "proto3-json-serializer": {
-              "version": "1.0.0",
-              "dev": true,
-              "requires": {
-                "protobufjs": "^6.11.2"
-              }
-            },
-            "retry-request": {
-              "version": "5.0.0",
-              "dev": true,
-              "requires": {
-                "debug": "^4.1.1",
-                "extend": "^3.0.2"
-              }
-            }
-          }
-        },
-        "@grpc/grpc-js": {
-          "version": "1.6.7",
-          "dev": true,
-          "requires": {
-            "@grpc/proto-loader": "^0.6.4",
-            "@types/node": ">=12.12.47"
-          },
-          "dependencies": {
-            "@grpc/proto-loader": {
-              "version": "0.6.9",
-              "dev": true,
-              "requires": {
-                "@types/long": "^4.0.1",
-                "lodash.camelcase": "^4.3.0",
-                "long": "^4.0.0",
-                "protobufjs": "^6.10.0",
-                "yargs": "^16.2.0"
               }
             }
           }
@@ -25294,50 +23224,6 @@
           "version": "1.2.0",
           "dev": true
         },
-        "@protobufjs/aspromise": {
-          "version": "1.1.2",
-          "dev": true
-        },
-        "@protobufjs/base64": {
-          "version": "1.1.2",
-          "dev": true
-        },
-        "@protobufjs/codegen": {
-          "version": "2.0.4",
-          "dev": true
-        },
-        "@protobufjs/eventemitter": {
-          "version": "1.1.0",
-          "dev": true
-        },
-        "@protobufjs/fetch": {
-          "version": "1.1.0",
-          "dev": true,
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.1",
-            "@protobufjs/inquire": "^1.1.0"
-          }
-        },
-        "@protobufjs/float": {
-          "version": "1.0.2",
-          "dev": true
-        },
-        "@protobufjs/inquire": {
-          "version": "1.1.0",
-          "dev": true
-        },
-        "@protobufjs/path": {
-          "version": "1.1.2",
-          "dev": true
-        },
-        "@protobufjs/pool": {
-          "version": "1.1.0",
-          "dev": true
-        },
-        "@protobufjs/utf8": {
-          "version": "1.1.0",
-          "dev": true
-        },
         "@sindresorhus/is": {
           "version": "0.14.0",
           "dev": true
@@ -25351,10 +23237,6 @@
         },
         "@tootallnate/once": {
           "version": "1.1.2",
-          "dev": true
-        },
-        "@types/color-name": {
-          "version": "1.1.1",
           "dev": true
         },
         "@types/duplexify": {
@@ -25437,15 +23319,6 @@
             }
           }
         },
-        "aggregate-error": {
-          "version": "3.1.0",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "clean-stack": "^2.0.0",
-            "indent-string": "^4.0.0"
-          }
-        },
         "ajv-formats": {
           "version": "2.1.1",
           "dev": true,
@@ -25496,14 +23369,6 @@
         "ansicolors": {
           "version": "0.3.2",
           "dev": true
-        },
-        "anymatch": {
-          "version": "3.1.2",
-          "dev": true,
-          "requires": {
-            "normalize-path": "^3.0.0",
-            "picomatch": "^2.0.4"
-          }
         },
         "aproba": {
           "version": "2.0.0",
@@ -25580,10 +23445,6 @@
           "version": "1.1.1",
           "dev": true
         },
-        "arrify": {
-          "version": "2.0.1",
-          "dev": true
-        },
         "as-array": {
           "version": "2.0.0",
           "dev": true
@@ -25604,12 +23465,6 @@
           "dev": true,
           "requires": {
             "tslib": "^2.0.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "2.3.1",
-              "dev": true
-            }
           }
         },
         "async": {
@@ -25623,24 +23478,12 @@
           "version": "1.3.2",
           "dev": true
         },
-        "asynckit": {
-          "version": "0.4.0",
-          "dev": true
-        },
         "aws-sign2": {
           "version": "0.7.0",
           "dev": true
         },
         "aws4": {
           "version": "1.8.0",
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "base64-js": {
-          "version": "1.3.0",
           "dev": true
         },
         "basic-auth": {
@@ -25665,29 +23508,12 @@
           "version": "1.6.48",
           "dev": true
         },
-        "bignumber.js": {
-          "version": "9.0.2",
-          "dev": true
-        },
         "binary": {
           "version": "0.3.0",
           "dev": true,
           "requires": {
             "buffers": "~0.1.1",
             "chainsaw": "~0.1.0"
-          }
-        },
-        "binary-extensions": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "bl": {
-          "version": "4.1.0",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
           }
         },
         "bluebird": {
@@ -25724,42 +23550,12 @@
             "widest-line": "^3.1.0"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "4.2.1",
-              "dev": true,
-              "requires": {
-                "@types/color-name": "^1.1.1",
-                "color-convert": "^2.0.1"
-              }
-            },
             "chalk": {
               "version": "3.0.0",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "dev": true,
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "dev": true
-            },
-            "has-flag": {
-              "version": "4.0.0",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "7.1.0",
-              "dev": true,
-              "requires": {
-                "has-flag": "^4.0.0"
               }
             }
           }
@@ -25772,33 +23568,8 @@
             "concat-map": "0.0.1"
           }
         },
-        "braces": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "buffer": {
-          "version": "5.7.1",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          },
-          "dependencies": {
-            "base64-js": {
-              "version": "1.5.1",
-              "dev": true
-            }
-          }
-        },
         "buffer-crc32": {
           "version": "0.2.13",
-          "dev": true
-        },
-        "buffer-equal-constant-time": {
-          "version": "1.0.1",
           "dev": true
         },
         "buffer-indexof-polyfill": {
@@ -25838,23 +23609,10 @@
             "unique-filename": "^1.1.1"
           },
           "dependencies": {
-            "chownr": {
-              "version": "2.0.0",
-              "dev": true,
-              "optional": true
-            },
             "mkdirp": {
               "version": "1.0.4",
               "dev": true,
               "optional": true
-            },
-            "p-map": {
-              "version": "4.0.0",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "aggregate-error": "^3.0.0"
-              }
             }
           }
         },
@@ -25884,10 +23642,6 @@
             }
           }
         },
-        "camelcase": {
-          "version": "5.3.1",
-          "dev": true
-        },
         "cardinal": {
           "version": "2.1.1",
           "dev": true,
@@ -25907,24 +23661,6 @@
             "traverse": ">=0.3.0 <0.4"
           }
         },
-        "chardet": {
-          "version": "0.7.0",
-          "dev": true
-        },
-        "chokidar": {
-          "version": "3.5.3",
-          "dev": true,
-          "requires": {
-            "anymatch": "~3.1.2",
-            "braces": "~3.0.2",
-            "fsevents": "~2.3.2",
-            "glob-parent": "~5.1.2",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.6.0"
-          }
-        },
         "ci-info": {
           "version": "2.0.0",
           "dev": true
@@ -25936,24 +23672,8 @@
             "json-parse-helpfulerror": "^1.0.3"
           }
         },
-        "clean-stack": {
-          "version": "2.2.0",
-          "dev": true,
-          "optional": true
-        },
         "cli-boxes": {
           "version": "2.2.1",
-          "dev": true
-        },
-        "cli-cursor": {
-          "version": "3.1.0",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^3.1.0"
-          }
-        },
-        "cli-spinners": {
-          "version": "2.6.1",
           "dev": true
         },
         "cli-table": {
@@ -25970,23 +23690,6 @@
             "@colors/colors": "1.5.0",
             "string-width": "^4.2.0"
           }
-        },
-        "cli-width": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "clone": {
-          "version": "1.0.4",
-          "dev": true
         },
         "clone-response": {
           "version": "1.0.2",
@@ -26027,10 +23730,6 @@
           "dev": true,
           "optional": true
         },
-        "colorette": {
-          "version": "2.0.19",
-          "dev": true
-        },
         "colornames": {
           "version": "1.1.1",
           "dev": true
@@ -26045,13 +23744,6 @@
           "requires": {
             "color": "3.0.x",
             "text-hex": "1.0.x"
-          }
-        },
-        "combined-stream": {
-          "version": "1.0.8",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
           }
         },
         "commander": {
@@ -26075,13 +23767,6 @@
             "readable-stream": "^3.6.0"
           }
         },
-        "compressible": {
-          "version": "2.0.17",
-          "dev": true,
-          "requires": {
-            "mime-db": ">= 1.40.0 < 2"
-          }
-        },
         "compression": {
           "version": "1.7.4",
           "dev": true,
@@ -26100,10 +23785,6 @@
               "dev": true
             }
           }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "dev": true
         },
         "configstore": {
           "version": "5.0.1",
@@ -26163,10 +23844,6 @@
             "safe-buffer": "5.1.2"
           }
         },
-        "content-type": {
-          "version": "1.0.4",
-          "dev": true
-        },
         "cookie": {
           "version": "0.4.0",
           "dev": true
@@ -26178,14 +23855,6 @@
         "core-util-is": {
           "version": "1.0.2",
           "dev": true
-        },
-        "cors": {
-          "version": "2.8.5",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4",
-            "vary": "^1"
-          }
         },
         "crc-32": {
           "version": "1.2.0",
@@ -26224,39 +23893,6 @@
             }
           }
         },
-        "cross-spawn": {
-          "version": "7.0.3",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          },
-          "dependencies": {
-            "path-key": {
-              "version": "3.1.1",
-              "dev": true
-            },
-            "shebang-command": {
-              "version": "2.0.0",
-              "dev": true,
-              "requires": {
-                "shebang-regex": "^3.0.0"
-              }
-            },
-            "shebang-regex": {
-              "version": "3.0.0",
-              "dev": true
-            },
-            "which": {
-              "version": "2.0.2",
-              "dev": true,
-              "requires": {
-                "isexe": "^2.0.0"
-              }
-            }
-          }
-        },
         "csv-parse": {
           "version": "5.0.4",
           "dev": true
@@ -26286,24 +23922,9 @@
             "mimic-response": "^1.0.0"
           }
         },
-        "deep-extend": {
-          "version": "0.6.0",
-          "dev": true
-        },
         "deep-freeze": {
           "version": "0.0.1",
           "dev": true
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "dev": true
-        },
-        "defaults": {
-          "version": "1.0.3",
-          "dev": true,
-          "requires": {
-            "clone": "^1.0.2"
-          }
         },
         "defer-to-connect": {
           "version": "1.1.3",
@@ -26318,15 +23939,6 @@
             "esprima": "^4.0.0",
             "vm2": "^3.9.3"
           }
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "dev": true,
-          "optional": true
         },
         "depd": {
           "version": "1.1.2",
@@ -26371,16 +23983,6 @@
           "version": "0.1.4",
           "dev": true
         },
-        "duplexify": {
-          "version": "4.1.1",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.4.1",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1",
-            "stream-shift": "^1.0.0"
-          }
-        },
         "ecc-jsbn": {
           "version": "0.1.2",
           "dev": true,
@@ -26389,55 +23991,11 @@
             "safer-buffer": "^2.1.0"
           }
         },
-        "ecdsa-sig-formatter": {
-          "version": "1.0.11",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "ee-first": {
-          "version": "1.1.1",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "dev": true
-        },
         "enabled": {
           "version": "1.0.2",
           "dev": true,
           "requires": {
             "env-variable": "0.0.x"
-          }
-        },
-        "encodeurl": {
-          "version": "1.0.2",
-          "dev": true
-        },
-        "encoding": {
-          "version": "0.1.13",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "iconv-lite": "^0.6.2"
-          },
-          "dependencies": {
-            "iconv-lite": {
-              "version": "0.6.3",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-              }
-            }
-          }
-        },
-        "end-of-stream": {
-          "version": "1.4.1",
-          "dev": true,
-          "requires": {
-            "once": "^1.4.0"
           }
         },
         "env-paths": {
@@ -26449,63 +24007,12 @@
           "version": "0.0.6",
           "dev": true
         },
-        "err-code": {
-          "version": "2.0.3",
-          "dev": true,
-          "optional": true
-        },
-        "escalade": {
-          "version": "3.1.1",
-          "dev": true
-        },
         "escape-goat": {
           "version": "2.1.1",
           "dev": true
         },
-        "escape-html": {
-          "version": "1.0.3",
-          "dev": true
-        },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "dev": true
-        },
-        "escodegen": {
-          "version": "1.14.3",
-          "dev": true,
-          "requires": {
-            "esprima": "^4.0.1",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "esprima": {
-          "version": "4.0.1",
-          "dev": true
-        },
-        "estraverse": {
-          "version": "4.3.0",
-          "dev": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "dev": true
-        },
-        "etag": {
-          "version": "1.8.1",
-          "dev": true
-        },
-        "event-target-shim": {
-          "version": "5.0.1",
           "dev": true
         },
         "events-listener": {
@@ -26605,46 +24112,12 @@
             "vary": "~1.1.2"
           }
         },
-        "extend": {
-          "version": "3.0.2",
-          "dev": true
-        },
-        "external-editor": {
-          "version": "3.1.0",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
-          },
-          "dependencies": {
-            "tmp": {
-              "version": "0.0.33",
-              "dev": true,
-              "requires": {
-                "os-tmpdir": "~1.0.2"
-              }
-            }
-          }
-        },
         "extsprintf": {
           "version": "1.3.0",
           "dev": true
         },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "dev": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "dev": true
-        },
         "fast-safe-stringify": {
           "version": "2.1.1",
-          "dev": true
-        },
-        "fast-text-encoding": {
-          "version": "1.0.3",
           "dev": true
         },
         "fast-url-parser": {
@@ -26664,13 +24137,6 @@
           "version": "2.3.3",
           "dev": true
         },
-        "figures": {
-          "version": "3.2.0",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
         "file-uri-to-path": {
           "version": "2.0.0",
           "dev": true
@@ -26678,13 +24144,6 @@
         "filesize": {
           "version": "6.1.0",
           "dev": true
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
         },
         "finalhandler": {
           "version": "1.1.2",
@@ -26715,10 +24174,6 @@
               "requires": {
                 "lru-cache": "^6.0.0"
               }
-            },
-            "tslib": {
-              "version": "2.3.1",
-              "dev": true
             }
           }
         },
@@ -26737,10 +24192,6 @@
         },
         "forwarded": {
           "version": "0.1.2",
-          "dev": true
-        },
-        "fresh": {
-          "version": "0.5.2",
           "dev": true
         },
         "fs-constants": {
@@ -26769,22 +24220,6 @@
               "dev": true
             }
           }
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "fsevents": {
-          "version": "2.3.2",
-          "dev": true,
-          "optional": true
         },
         "fstream": {
           "version": "1.0.12",
@@ -26898,10 +24333,6 @@
             }
           }
         },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "dev": true
-        },
         "get-stream": {
           "version": "4.1.0",
           "dev": true,
@@ -26960,13 +24391,6 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          }
-        },
-        "glob-parent": {
-          "version": "5.1.2",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
           }
         },
         "glob-slash": {
@@ -27028,12 +24452,6 @@
           "dev": true,
           "requires": {
             "node-forge": "^1.0.0"
-          },
-          "dependencies": {
-            "node-forge": {
-              "version": "1.3.1",
-              "dev": true
-            }
           }
         },
         "googleapis": {
@@ -27126,10 +24544,6 @@
                 "jwa": "^2.0.0",
                 "safe-buffer": "^5.0.1"
               }
-            },
-            "node-forge": {
-              "version": "1.3.1",
-              "dev": true
             }
           }
         },
@@ -27228,10 +24642,6 @@
                 "jwa": "^2.0.0",
                 "safe-buffer": "^5.0.1"
               }
-            },
-            "node-forge": {
-              "version": "1.3.1",
-              "dev": true
             }
           }
         },
@@ -27251,10 +24661,6 @@
             "to-readable-stream": "^1.0.0",
             "url-parse-lax": "^3.0.0"
           }
-        },
-        "graceful-fs": {
-          "version": "4.2.9",
-          "dev": true
         },
         "gtoken": {
           "version": "5.3.2",
@@ -27296,13 +24702,6 @@
             "har-schema": "^2.0.0"
           }
         },
-        "has-ansi": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
         "has-unicode": {
           "version": "2.0.1",
           "dev": true,
@@ -27310,10 +24709,6 @@
         },
         "has-yarn": {
           "version": "2.1.0",
-          "dev": true
-        },
-        "http-cache-semantics": {
-          "version": "4.1.0",
           "dev": true
         },
         "http-errors": {
@@ -27364,35 +24759,6 @@
             "sshpk": "^1.7.0"
           }
         },
-        "https-proxy-agent": {
-          "version": "5.0.0",
-          "dev": true,
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.1.1",
-              "dev": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "ms": {
-              "version": "2.1.2",
-              "dev": true
-            }
-          }
-        },
-        "humanize-ms": {
-          "version": "1.2.1",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "^2.0.0"
-          }
-        },
         "iconv-lite": {
           "version": "0.4.24",
           "dev": true,
@@ -27400,113 +24766,9 @@
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
-        "ieee754": {
-          "version": "1.2.1",
-          "dev": true
-        },
         "import-lazy": {
           "version": "2.1.0",
           "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "4.0.0",
-          "dev": true,
-          "optional": true
-        },
-        "infer-owner": {
-          "version": "1.0.4",
-          "dev": true,
-          "optional": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.8",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "8.2.0",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^4.2.1",
-            "chalk": "^4.1.1",
-            "cli-cursor": "^3.1.0",
-            "cli-width": "^3.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^3.0.0",
-            "lodash": "^4.17.21",
-            "mute-stream": "0.0.8",
-            "ora": "^5.4.1",
-            "run-async": "^2.4.0",
-            "rxjs": "^7.2.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0",
-            "through": "^2.3.6"
-          },
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "4.3.2",
-              "dev": true,
-              "requires": {
-                "type-fest": "^0.21.3"
-              }
-            },
-            "ansi-styles": {
-              "version": "4.3.0",
-              "dev": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "chalk": {
-              "version": "4.1.2",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "dev": true,
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "dev": true
-            },
-            "has-flag": {
-              "version": "4.0.0",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "7.2.0",
-              "dev": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            },
-            "type-fest": {
-              "version": "0.21.3",
-              "dev": true
-            }
-          }
         },
         "install-artifact-from-github": {
           "version": "1.3.0",
@@ -27525,33 +24787,11 @@
           "version": "1.9.0",
           "dev": true
         },
-        "is-binary-path": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "binary-extensions": "^2.0.0"
-          }
-        },
         "is-ci": {
           "version": "2.0.0",
           "dev": true,
           "requires": {
             "ci-info": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.3",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
           }
         },
         "is-installed-globally": {
@@ -27562,21 +24802,8 @@
             "is-path-inside": "^3.0.1"
           }
         },
-        "is-interactive": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "is-lambda": {
-          "version": "1.0.1",
-          "dev": true,
-          "optional": true
-        },
         "is-npm": {
           "version": "4.0.0",
-          "dev": true
-        },
-        "is-number": {
-          "version": "7.0.0",
           "dev": true
         },
         "is-path-inside": {
@@ -27587,24 +24814,12 @@
           "version": "1.1.0",
           "dev": true
         },
-        "is-stream-ended": {
-          "version": "0.1.4",
-          "dev": true
-        },
         "is-typedarray": {
           "version": "1.0.0",
           "dev": true
         },
-        "is-unicode-supported": {
-          "version": "0.1.0",
-          "dev": true
-        },
         "is-url": {
           "version": "1.2.4",
-          "dev": true
-        },
-        "is-windows": {
-          "version": "1.0.2",
           "dev": true
         },
         "is-wsl": {
@@ -27623,14 +24838,6 @@
             "ip-regex": "^4.1.0",
             "is-url": "^1.2.4"
           }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -27661,13 +24868,6 @@
           "version": "0.1.1",
           "dev": true
         },
-        "json-bigint": {
-          "version": "1.0.0",
-          "dev": true,
-          "requires": {
-            "bignumber.js": "^9.0.0"
-          }
-        },
         "json-buffer": {
           "version": "3.0.0",
           "dev": true
@@ -27691,37 +24891,11 @@
           "version": "5.0.1",
           "dev": true
         },
-        "jsonc-parser": {
-          "version": "3.0.0",
-          "dev": true
-        },
         "jsonfile": {
           "version": "4.0.0",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
-          }
-        },
-        "jsonwebtoken": {
-          "version": "8.5.1",
-          "dev": true,
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash.includes": "^4.3.0",
-            "lodash.isboolean": "^3.0.3",
-            "lodash.isinteger": "^4.0.4",
-            "lodash.isnumber": "^3.0.3",
-            "lodash.isplainobject": "^4.0.6",
-            "lodash.isstring": "^4.0.1",
-            "lodash.once": "^4.0.0",
-            "ms": "^2.1.1",
-            "semver": "^5.6.0"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.3",
-              "dev": true
-            }
           }
         },
         "jsprim": {
@@ -27732,23 +24906,6 @@
             "extsprintf": "1.3.0",
             "json-schema": "0.4.0",
             "verror": "1.10.0"
-          }
-        },
-        "jwa": {
-          "version": "1.4.1",
-          "dev": true,
-          "requires": {
-            "buffer-equal-constant-time": "1.0.1",
-            "ecdsa-sig-formatter": "1.0.11",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "jws": {
-          "version": "3.2.2",
-          "dev": true,
-          "requires": {
-            "jwa": "^1.4.1",
-            "safe-buffer": "^5.0.1"
           }
         },
         "keyv": {
@@ -27794,14 +24951,6 @@
             }
           }
         },
-        "levn": {
-          "version": "0.3.0",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
         "libsodium": {
           "version": "0.7.10",
           "dev": true
@@ -27817,16 +24966,8 @@
           "version": "1.0.1",
           "dev": true
         },
-        "lodash": {
-          "version": "4.17.21",
-          "dev": true
-        },
         "lodash._objecttypes": {
           "version": "2.4.1",
-          "dev": true
-        },
-        "lodash.camelcase": {
-          "version": "4.3.0",
           "dev": true
         },
         "lodash.defaults": {
@@ -27841,40 +24982,12 @@
           "version": "4.4.0",
           "dev": true
         },
-        "lodash.includes": {
-          "version": "4.3.0",
-          "dev": true
-        },
-        "lodash.isboolean": {
-          "version": "3.0.3",
-          "dev": true
-        },
-        "lodash.isinteger": {
-          "version": "4.0.4",
-          "dev": true
-        },
-        "lodash.isnumber": {
-          "version": "3.0.3",
-          "dev": true
-        },
         "lodash.isobject": {
           "version": "2.4.1",
           "dev": true,
           "requires": {
             "lodash._objecttypes": "~2.4.1"
           }
-        },
-        "lodash.isplainobject": {
-          "version": "4.0.6",
-          "dev": true
-        },
-        "lodash.isstring": {
-          "version": "4.0.1",
-          "dev": true
-        },
-        "lodash.once": {
-          "version": "4.1.1",
-          "dev": true
         },
         "lodash.snakecase": {
           "version": "4.1.1",
@@ -27883,53 +24996,6 @@
         "lodash.union": {
           "version": "4.6.0",
           "dev": true
-        },
-        "log-symbols": {
-          "version": "4.1.0",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "is-unicode-supported": "^0.1.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "dev": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "chalk": {
-              "version": "4.1.2",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "dev": true,
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "dev": true
-            },
-            "has-flag": {
-              "version": "4.0.0",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "7.2.0",
-              "dev": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
         },
         "logform": {
           "version": "2.1.2",
@@ -27952,20 +25018,9 @@
             }
           }
         },
-        "long": {
-          "version": "4.0.0",
-          "dev": true
-        },
         "lowercase-keys": {
           "version": "1.0.1",
           "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
         },
         "make-dir": {
           "version": "3.1.0",
@@ -28028,10 +25083,6 @@
             }
           }
         },
-        "marked": {
-          "version": "4.0.14",
-          "dev": true
-        },
         "marked-terminal": {
           "version": "5.1.1",
           "dev": true,
@@ -28050,31 +25101,12 @@
             }
           }
         },
-        "media-typer": {
-          "version": "0.3.0",
-          "dev": true
-        },
         "merge-descriptors": {
           "version": "1.0.1",
           "dev": true
         },
         "mime": {
           "version": "2.5.2",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.40.0",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.24",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.40.0"
-          }
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
           "dev": true
         },
         "mimic-response": {
@@ -28088,25 +25120,6 @@
             "brace-expansion": "^1.1.7"
           }
         },
-        "minimist": {
-          "version": "1.2.6",
-          "dev": true
-        },
-        "minipass": {
-          "version": "3.1.6",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minipass-collect": {
-          "version": "1.0.2",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
         "minipass-fetch": {
           "version": "1.4.1",
           "dev": true,
@@ -28116,38 +25129,6 @@
             "minipass": "^3.1.0",
             "minipass-sized": "^1.0.3",
             "minizlib": "^2.0.0"
-          }
-        },
-        "minipass-flush": {
-          "version": "1.0.5",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "minipass-pipeline": {
-          "version": "1.2.4",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "minipass-sized": {
-          "version": "1.0.3",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.0.0",
-            "yallist": "^4.0.0"
           }
         },
         "mkdirp": {
@@ -28178,18 +25159,10 @@
           "version": "2.0.0",
           "dev": true
         },
-        "mute-stream": {
-          "version": "0.0.8",
-          "dev": true
-        },
         "nan": {
           "version": "2.15.0",
           "dev": true,
           "optional": true
-        },
-        "negotiator": {
-          "version": "0.6.2",
-          "dev": true
         },
         "netmask": {
           "version": "2.0.2",
@@ -28256,10 +25229,6 @@
             "abbrev": "1"
           }
         },
-        "normalize-path": {
-          "version": "3.0.0",
-          "dev": true
-        },
         "normalize-url": {
           "version": "4.5.1",
           "dev": true
@@ -28279,42 +25248,13 @@
           "version": "0.9.0",
           "dev": true
         },
-        "object-assign": {
-          "version": "4.1.1",
-          "dev": true
-        },
-        "object-hash": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "on-finished": {
-          "version": "2.3.0",
-          "dev": true,
-          "requires": {
-            "ee-first": "1.1.1"
-          }
-        },
         "on-headers": {
           "version": "1.0.2",
           "dev": true
         },
-        "once": {
-          "version": "1.4.0",
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
         "one-time": {
           "version": "0.0.4",
           "dev": true
-        },
-        "onetime": {
-          "version": "5.1.2",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^2.1.0"
-          }
         },
         "open": {
           "version": "6.4.0",
@@ -28329,76 +25269,6 @@
           "requires": {
             "yaml": "^1.10.0"
           }
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "dev": true,
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
-          }
-        },
-        "ora": {
-          "version": "5.4.1",
-          "dev": true,
-          "requires": {
-            "bl": "^4.1.0",
-            "chalk": "^4.1.0",
-            "cli-cursor": "^3.1.0",
-            "cli-spinners": "^2.5.0",
-            "is-interactive": "^1.0.0",
-            "is-unicode-supported": "^0.1.0",
-            "log-symbols": "^4.1.0",
-            "strip-ansi": "^6.0.0",
-            "wcwidth": "^1.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "dev": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "chalk": {
-              "version": "4.1.2",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "dev": true,
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "dev": true
-            },
-            "has-flag": {
-              "version": "4.0.0",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "7.2.0",
-              "dev": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "dev": true
         },
         "p-cancelable": {
           "version": "1.1.0",
@@ -28461,14 +25331,6 @@
             }
           }
         },
-        "parseurl": {
-          "version": "1.3.3",
-          "dev": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "dev": true
-        },
         "path-key": {
           "version": "2.0.1",
           "dev": true
@@ -28481,46 +25343,12 @@
           "version": "2.1.0",
           "dev": true
         },
-        "picomatch": {
-          "version": "2.3.1",
-          "dev": true
-        },
-        "portfinder": {
-          "version": "1.0.28",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.2",
-            "debug": "^3.1.1",
-            "mkdirp": "^0.5.5"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.7",
-              "dev": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "ms": {
-              "version": "2.1.3",
-              "dev": true
-            }
-          }
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "dev": true
-        },
         "prepend-http": {
           "version": "2.0.0",
           "dev": true
         },
         "printj": {
           "version": "1.1.2",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
           "dev": true
         },
         "progress": {
@@ -28530,52 +25358,6 @@
         "promise-breaker": {
           "version": "5.0.0",
           "dev": true
-        },
-        "promise-inflight": {
-          "version": "1.0.1",
-          "dev": true,
-          "optional": true
-        },
-        "promise-retry": {
-          "version": "2.0.1",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "err-code": "^2.0.2",
-            "retry": "^0.12.0"
-          },
-          "dependencies": {
-            "retry": {
-              "version": "0.12.0",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "protobufjs": {
-          "version": "6.11.3",
-          "dev": true,
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.1",
-            "@types/node": ">=13.7.0",
-            "long": "^4.0.0"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "17.0.8",
-              "dev": true
-            }
-          }
         },
         "proxy-addr": {
           "version": "2.0.5",
@@ -28639,10 +25421,6 @@
             "once": "^1.3.1"
           }
         },
-        "punycode": {
-          "version": "2.1.1",
-          "dev": true
-        },
         "pupa": {
           "version": "2.1.1",
           "dev": true,
@@ -28652,10 +25430,6 @@
         },
         "qs": {
           "version": "6.7.0",
-          "dev": true
-        },
-        "range-parser": {
-          "version": "1.2.1",
           "dev": true
         },
         "raw-body": {
@@ -28688,27 +25462,11 @@
             "node-gyp": "^8.4.1"
           }
         },
-        "readable-stream": {
-          "version": "3.6.0",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
         "readdir-glob": {
           "version": "1.1.1",
           "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
-          }
-        },
-        "readdirp": {
-          "version": "3.6.0",
-          "dev": true,
-          "requires": {
-            "picomatch": "^2.2.1"
           }
         },
         "redeyed": {
@@ -28777,10 +25535,6 @@
             }
           }
         },
-        "require-directory": {
-          "version": "2.1.1",
-          "dev": true
-        },
         "require-from-string": {
           "version": "2.0.2",
           "dev": true
@@ -28792,24 +25546,9 @@
             "lowercase-keys": "^1.0.0"
           }
         },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "dev": true,
-          "requires": {
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
         "retry": {
           "version": "0.13.1",
           "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
         },
         "router": {
           "version": "1.3.5",
@@ -28833,31 +25572,6 @@
               "dev": true
             }
           }
-        },
-        "run-async": {
-          "version": "2.4.1",
-          "dev": true
-        },
-        "rxjs": {
-          "version": "7.5.1",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "2.3.1",
-              "dev": true
-            }
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "dev": true
         },
         "semver": {
           "version": "5.7.1",
@@ -28915,15 +25629,6 @@
             "send": "0.17.1"
           }
         },
-        "set-blocking": {
-          "version": "2.0.0",
-          "dev": true,
-          "optional": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "dev": true
-        },
         "setprototypeof": {
           "version": "1.1.1",
           "dev": true
@@ -28939,10 +25644,6 @@
           "version": "1.0.0",
           "dev": true
         },
-        "signal-exit": {
-          "version": "3.0.2",
-          "dev": true
-        },
         "simple-swizzle": {
           "version": "0.2.2",
           "dev": true,
@@ -28954,18 +25655,6 @@
               "version": "0.3.2",
               "dev": true
             }
-          }
-        },
-        "smart-buffer": {
-          "version": "4.2.0",
-          "dev": true
-        },
-        "socks": {
-          "version": "2.6.1",
-          "dev": true,
-          "requires": {
-            "ip": "^1.1.5",
-            "smart-buffer": "^4.1.0"
           }
         },
         "socks-proxy-agent": {
@@ -28989,10 +25678,6 @@
               "dev": true
             }
           }
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "dev": true
         },
         "sshpk": {
           "version": "1.16.1",
@@ -29036,17 +25721,6 @@
             "stream-chain": "^2.2.4"
           }
         },
-        "stream-shift": {
-          "version": "1.0.1",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
         "string-length": {
           "version": "1.0.1",
           "dev": true,
@@ -29060,28 +25734,6 @@
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
-            }
-          }
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.1",
-              "dev": true
             }
           }
         },
@@ -29145,10 +25797,6 @@
             },
             "commander": {
               "version": "9.2.0",
-              "dev": true
-            },
-            "has-flag": {
-              "version": "4.0.0",
               "dev": true
             },
             "isarray": {
@@ -29224,41 +25872,6 @@
           "requires": {
             "has-flag": "^4.0.0",
             "supports-color": "^7.0.0"
-          },
-          "dependencies": {
-            "has-flag": {
-              "version": "4.0.0",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "7.2.0",
-              "dev": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
-        },
-        "tar": {
-          "version": "6.1.11",
-          "dev": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^3.0.0",
-            "minizlib": "^2.1.1",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
-          },
-          "dependencies": {
-            "chownr": {
-              "version": "2.0.0",
-              "dev": true
-            },
-            "mkdirp": {
-              "version": "1.0.4",
-              "dev": true
-            }
           }
         },
         "tar-stream": {
@@ -29301,27 +25914,9 @@
           "version": "1.0.0",
           "dev": true
         },
-        "through": {
-          "version": "2.3.8",
-          "dev": true
-        },
-        "tmp": {
-          "version": "0.2.1",
-          "dev": true,
-          "requires": {
-            "rimraf": "^3.0.0"
-          }
-        },
         "to-readable-stream": {
           "version": "1.0.0",
           "dev": true
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
         },
         "toidentifier": {
           "version": "1.0.0",
@@ -29342,10 +25937,6 @@
             "lodash": "^4.17.10"
           }
         },
-        "tr46": {
-          "version": "0.0.3",
-          "dev": true
-        },
         "traverse": {
           "version": "0.3.9",
           "dev": true
@@ -29365,24 +25956,9 @@
           "version": "0.14.5",
           "dev": true
         },
-        "type-check": {
-          "version": "0.3.2",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
-        },
         "type-fest": {
           "version": "0.8.1",
           "dev": true
-        },
-        "type-is": {
-          "version": "1.6.18",
-          "dev": true,
-          "requires": {
-            "media-typer": "0.3.0",
-            "mime-types": "~2.1.24"
-          }
         },
         "typedarray-to-buffer": {
           "version": "3.1.5",
@@ -29427,14 +26003,6 @@
               "dev": true
             }
           }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "dev": true
-        },
-        "unpipe": {
-          "version": "1.0.0",
-          "dev": true
         },
         "unzipper": {
           "version": "0.10.10",
@@ -29487,13 +26055,6 @@
             "xdg-basedir": "^4.0.0"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "dev": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
             "boxen": {
               "version": "5.1.2",
               "dev": true,
@@ -29512,35 +26073,12 @@
               "version": "6.2.0",
               "dev": true
             },
-            "chalk": {
-              "version": "4.1.0",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "dev": true,
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "dev": true
-            },
             "global-dirs": {
               "version": "3.0.0",
               "dev": true,
               "requires": {
                 "ini": "2.0.0"
               }
-            },
-            "has-flag": {
-              "version": "4.0.0",
-              "dev": true
             },
             "ini": {
               "version": "2.0.0",
@@ -29565,13 +26103,6 @@
                 "lru-cache": "^6.0.0"
               }
             },
-            "supports-color": {
-              "version": "7.2.0",
-              "dev": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            },
             "type-fest": {
               "version": "0.20.2",
               "dev": true
@@ -29593,24 +26124,8 @@
           "version": "2.0.8",
           "dev": true
         },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "dev": true
-        },
-        "utils-merge": {
-          "version": "1.0.1",
-          "dev": true
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "dev": true
-        },
         "valid-url": {
           "version": "1.0.9",
-          "dev": true
-        },
-        "vary": {
-          "version": "1.1.2",
           "dev": true
         },
         "verror": {
@@ -29620,13 +26135,6 @@
             "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
             "extsprintf": "^1.2.0"
-          }
-        },
-        "wcwidth": {
-          "version": "1.0.1",
-          "dev": true,
-          "requires": {
-            "defaults": "^1.0.3"
           }
         },
         "webidl-conversions": {
@@ -29701,43 +26209,6 @@
             }
           }
         },
-        "word-wrap": {
-          "version": "1.2.3",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "dev": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "dev": true,
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "dev": true
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "dev": true
-        },
         "write-file-atomic": {
           "version": "3.0.3",
           "dev": true,
@@ -29759,37 +26230,6 @@
         },
         "xregexp": {
           "version": "2.0.0",
-          "dev": true
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "yaml": {
-          "version": "1.10.0",
-          "dev": true
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          },
-          "dependencies": {
-            "y18n": {
-              "version": "5.0.8",
-              "dev": true
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.4",
           "dev": true
         },
         "zip-stream": {
@@ -30079,11 +26519,45 @@
             "concat-map": "0.0.1"
           }
         },
+        "cosmiconfig-typescript-loader": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.1.tgz",
+          "integrity": "sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==",
+          "dev": true,
+          "requires": {}
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
         "minimatch": {
           "version": "4.2.1",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
+          }
+        },
+        "ts-node": {
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+          "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+          "dev": true,
+          "requires": {
+            "@cspotcode/source-map-support": "^0.8.0",
+            "@tsconfig/node10": "^1.0.7",
+            "@tsconfig/node12": "^1.0.7",
+            "@tsconfig/node14": "^1.0.0",
+            "@tsconfig/node16": "^1.0.2",
+            "acorn": "^8.4.1",
+            "acorn-walk": "^8.1.1",
+            "arg": "^4.1.0",
+            "create-require": "^1.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "v8-compile-cache-lib": "^3.0.1",
+            "yn": "3.1.1"
           }
         }
       }
@@ -30111,14 +26585,13 @@
     },
     "graphql-tag": {
       "version": "2.12.6",
-      "dev": true,
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "graphql-ws": {
       "version": "5.10.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {}
     },
     "gray-matter": {
@@ -30247,6 +26720,14 @@
       "requires": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -31368,7 +27849,6 @@
     },
     "loose-envify": {
       "version": "1.4.0",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -31417,6 +27897,8 @@
     },
     "make-error": {
       "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "make-fetch-happen": {
@@ -31912,6 +28394,25 @@
         }
       }
     },
+    "optimism": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "requires": {
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
+      },
+      "dependencies": {
+        "@wry/context": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
+          "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        }
+      }
+    },
     "optionator": {
       "version": "0.8.3",
       "requires": {
@@ -32162,6 +28663,16 @@
         "retry": "^0.12.0"
       }
     },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "proper-lockfile": {
       "version": "4.1.2",
       "requires": {
@@ -32362,6 +28873,11 @@
           "version": "2.0.1"
         }
       }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "readable-stream": {
       "version": "3.6.0",
@@ -32588,6 +29104,11 @@
           "version": "2.0.0"
         }
       }
+    },
+    "response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw=="
     },
     "restore-cursor": {
       "version": "3.1.0",
@@ -33448,34 +29969,17 @@
     "tr46": {
       "version": "0.0.3"
     },
+    "ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "ts-log": {
       "version": "2.2.4",
       "dev": true
-    },
-    "ts-node": {
-      "version": "10.9.1",
-      "dev": true,
-      "requires": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "4.0.2",
-          "dev": true
-        }
-      }
     },
     "ts-simple-type": {
       "version": "1.0.7"
@@ -33503,17 +30007,6 @@
     "tsscmp": {
       "version": "1.0.6"
     },
-    "tsutils": {
-      "version": "3.21.0",
-      "requires": {
-        "tslib": "^1.8.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1"
-        }
-      }
-    },
     "type-check": {
       "version": "0.3.2",
       "requires": {
@@ -33532,7 +30025,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.3"
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
     },
     "typical": {
       "version": "4.0.0"
@@ -33693,6 +30188,8 @@
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "validate-npm-package-name": {
@@ -33963,10 +30460,25 @@
     },
     "yn": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0"
+    },
+    "zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "requires": {
+        "zen-observable": "0.8.15"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
       ]
     },
     "serve:dev": {
-      "command": "wds --root-dir=./packages/content/_dev --node-resolve --watch --open",
+      "command": "node --enable-source-maps packages/site-server/lib/dev-server.js",
       "files": [],
       "output": [],
       "dependencies": [
@@ -75,7 +75,8 @@
     "build:dev": {
       "dependencies": [
         "./packages/client:build:dev",
-        "./packages/content:build:dev"
+        "./packages/content:build:dev",
+        "./packages/site-server:build"
       ]
     },
     "build-and-check:dev": {

--- a/packages/client/src/components/wco-top-bar.ts
+++ b/packages/client/src/components/wco-top-bar.ts
@@ -26,7 +26,7 @@ export class WCOTopBar extends LitElement {
   `;
 
   render() {
-    return html` webcomponents.org `;
+    return html`🚧 webcomponents.org `;
   }
 }
 

--- a/packages/site-server/package.json
+++ b/packages/site-server/package.json
@@ -8,7 +8,8 @@
   "type": "module",
   "scripts": {
     "build": "wireit",
-    "check": "wireit"
+    "check": "wireit",
+    "serve:dev": "wireit"
   },
   "wireit": {
     "build": {
@@ -29,6 +30,12 @@
         "src/**/*.ts"
       ],
       "output": []
+    },
+    "serve:dev": {
+      "command": "node --enable-source-maps ./dev-server.js",
+      "dependencies": [
+        "build"
+      ]
     }
   },
   "dependencies": {
@@ -36,6 +43,7 @@
     "@types/koa-conditional-get": "^2.0.0",
     "@types/koa-etag": "^3.0.0",
     "@types/koa-static": "^4.0.2",
+    "@web/dev-server": "^0.1.34",
     "koa": "^2.13.4",
     "koa-conditional-get": "^3.0.0",
     "koa-etag": "^4.0.0",

--- a/packages/site-server/src/catalog/router.ts
+++ b/packages/site-server/src/catalog/router.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Router from '@koa/router';
+
+export const catalogRouter = new Router();
+
+catalogRouter.get('/element/:path+', async (context) => {
+  const {params} = context;
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const elementPath = params['path']!;
+  const elementPathSegments = elementPath.split('/');
+  const isScoped = elementPathSegments[0]?.startsWith('@');
+  const packageName = isScoped
+    ? elementPathSegments[0] + '/' + elementPathSegments[1]
+    : elementPathSegments[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+  const elementName = elementPathSegments[isScoped ? 2 : 1];
+  
+  context.body = `
+    <!doctype html>
+    <html>
+      <body>
+        <h1>${escapeHTML(`<${elementName}>`)}</h1>
+        <h2>In ${escapeHTML(packageName)}</h2>
+      </body>
+    </html>
+  `;
+  context.type = 'html';
+  context.status = 200;
+});
+
+const replacements: Record<string, string> = {
+  '<': '&lt;',
+  '>': '&gt;',
+  '&': '&amp;',
+  "'": '&#39;',
+  '"': '&quot;',
+};
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const replacer = (s: string) => replacements[s]!;
+const escapeHTML = (html: string) => html.replaceAll(/[<>&'"]/g, replacer);

--- a/packages/site-server/src/dev-server.ts
+++ b/packages/site-server/src/dev-server.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {DefaultContext, DefaultState, Middleware} from 'koa';
+import {fileURLToPath} from 'url';
+import Router from '@koa/router';
+import {catalogRouter} from './catalog/router.js';
+import {startDevServer} from '@web/dev-server';
+
+const PORT = process.env['PORT'] ? parseInt(process.env['PORT']) : 8080;
+const STATIC_ROOT = fileURLToPath(
+  new URL('../../content/_dev', import.meta.url)
+);
+
+console.log('Serving static files from', STATIC_ROOT);
+
+const router = new Router();
+router.use('/catalog', catalogRouter.routes());
+
+startDevServer({
+  config: {
+    port: PORT,
+    rootDir: STATIC_ROOT,
+    plugins: [],
+    middleware: [
+      router.routes() as Middleware<DefaultState, DefaultContext, unknown>,
+    ],
+    watch: true,
+    nodeResolve: true
+  },
+});

--- a/packages/site-server/tsconfig.json
+++ b/packages/site-server/tsconfig.json
@@ -3,8 +3,10 @@
   "compilerOptions": {
     "rootDir": "./src",
     "noEmit": true,
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
-  },
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
+    "module": "esnext",
+    "moduleResolution": "node", 
+},
   "include": ["src/**/*.ts"],
   "exclude": []
 }


### PR DESCRIPTION
Adds a custom dev server based on `@web/dev-server`, along with a Koa router middleware that handles the `/catalog` URL space.

Right now there's a simple hard-coded response wired in at `/catalog/element/:path` that parses the `:path` as a `packageName/elementName` pair and shows them on the page.

Part of https://github.com/webcomponents/webcomponents.org/issues/1346