### PR TITLE
Add validate script to CEM tools

### DIFF
--- a/packages/catalog-server/src/lib/npm.ts
+++ b/packages/catalog-server/src/lib/npm.ts
@@ -9,46 +9,7 @@
  * This module contains utilities for interacting with the npm registry and
  * downloading custom element manifests from it.
  */
-import fetch from 'node-fetch';
-import npmFetch from 'npm-registry-fetch';
-import {
-  PackageFiles,
-  Package,
-  Version,
-} from '@webcomponents/custom-elements-manifest-tools/lib/npm.js';
 import * as semver from 'semver';
-
-export class NpmAndUnpkgFiles implements PackageFiles {
-  /**
-   * Fetch package metadata from the npm registry.
-   *
-   * See https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md
-   */
-  getPackageMetadata(packageName: string): Promise<Package> {
-    return npmFetch.json(
-      `/${packageName}`
-    ) as Promise<unknown> as Promise<Package>;
-  }
-
-  getPackageVersionMetadata(
-    packageName: string,
-    version: string
-  ): Promise<Version> {
-    return npmFetch(
-      `/${packageName}/${version}`
-    ) as Promise<unknown> as Promise<Version>;
-  }
-
-  async getFile(
-    packageName: string,
-    version: string,
-    path: string
-  ): Promise<string> {
-    const unpkgUrl = `https://unpkg.com/${packageName}@${version}/${path}`;
-    const response = await fetch(unpkgUrl);
-    return response.text();
-  }
-}
 
 export const getDistTagsForVersion = (
   distTags: {[tag: string]: string},

--- a/packages/catalog-server/src/lib/server.ts
+++ b/packages/catalog-server/src/lib/server.ts
@@ -18,7 +18,7 @@ import bodyParser from 'koa-bodyparser';
 import {makeExecutableCatalogSchema} from './graphql.js';
 import {Catalog} from './catalog.js';
 import {FirestoreRepository} from './firestore/firestore-repository.js';
-import {NpmAndUnpkgFiles} from './npm.js';
+import {NpmAndUnpkgFiles} from '@webcomponents/custom-elements-manifest-tools/lib/npm-and-unpkg-files.js';
 
 export const makeServer = async () => {
   const files = new NpmAndUnpkgFiles();

--- a/packages/custom-elements-manifest-tools/.gitignore
+++ b/packages/custom-elements-manifest-tools/.gitignore
@@ -1,4 +1,5 @@
 /lib/
+/scripts/
 /node_modules/
 /test/*
 !/test/test-data/

--- a/packages/custom-elements-manifest-tools/src/lib/npm-and-unpkg-files.ts
+++ b/packages/custom-elements-manifest-tools/src/lib/npm-and-unpkg-files.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @overview
+ * This module contains utilities for interacting with the npm registry and
+ * downloading custom element manifests from it.
+ */
+ import fetch from 'node-fetch';
+ import npmFetch from 'npm-registry-fetch';
+ import {
+   PackageFiles,
+   Package,
+   Version,
+ } from './npm.js';
+ 
+ export class NpmAndUnpkgFiles implements PackageFiles {
+   /**
+    * Fetch package metadata from the npm registry.
+    *
+    * See https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md
+    */
+   getPackageMetadata(packageName: string): Promise<Package> {
+     return npmFetch.json(
+       `/${packageName}`
+     ) as Promise<unknown> as Promise<Package>;
+   }
+ 
+   getPackageVersionMetadata(
+     packageName: string,
+     version: string
+   ): Promise<Version> {
+     return npmFetch(
+       `/${packageName}/${version}`
+     ) as Promise<unknown> as Promise<Version>;
+   }
+ 
+   async getFile(
+     packageName: string,
+     version: string,
+     path: string
+   ): Promise<string> {
+     const unpkgUrl = `https://unpkg.com/${packageName}@${version}/${path}`;
+     const response = await fetch(unpkgUrl);
+     return response.text();
+   }
+ }
+ 

--- a/packages/custom-elements-manifest-tools/src/scripts/validate.ts
+++ b/packages/custom-elements-manifest-tools/src/scripts/validate.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {parseArgs} from 'node:util';
+import {validatePackage} from '../lib/validate.js';
+import {NpmAndUnpkgFiles} from '../lib/npm-and-unpkg-files.js';
+import {getCustomElements} from '../index.js';
+
+const {positionals} = parseArgs({allowPositionals: true});
+const files = new NpmAndUnpkgFiles();
+
+const packageName = positionals[0];
+if (packageName === undefined) {
+  console.error('No package name given');
+  process.exit(1);
+}
+
+const version = 'latest';
+console.log(`Validating ${packageName}@${version}`);
+const result = await validatePackage({packageName, version, files});
+
+if (result.manifestData !== undefined) {
+  const customElements = getCustomElements(
+    result.manifestData,
+    packageName,
+    version
+  );
+  const customElementsCount = customElements.length;
+  console.log(
+    `${customElementsCount} custom element${
+      customElementsCount === 1 ? '' : 's'
+    } found`
+  );
+}
+
+for (const problem of result.problems ?? []) {
+  console.log(problem);
+}

--- a/packages/site-server/package.json
+++ b/packages/site-server/package.json
@@ -35,7 +35,7 @@
       "output": []
     },
     "serve:dev": {
-      "command": "node --enable-source-maps ./dev-server.js",
+      "command": "node --enable-source-maps ./lib/dev-server.js",
       "dependencies": [
         "build"
       ]


### PR DESCRIPTION
This is handy to quickly test both the validator and npm packages.

I made it as a first step to including a hard-coded list of npm packages that we want to import to bootstrap as part of https://github.com/webcomponents/webcomponents.org/issues/1353