### PR TITLE
Implement basic full-text-search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3734,6 +3734,14 @@
       "version": "3.0.5",
       "license": "MIT"
     },
+    "node_modules/@types/natural": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/natural/-/natural-5.1.1.tgz",
+      "integrity": "sha512-BqppT8eHJvc0pN81XE7Rx5P8Osg1TSnOx3iwzLWImIO+6DwNUfpKR20tvg713O2eqHoxLcqrBaL10foo1mw/Xw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "18.8.3",
       "license": "MIT"
@@ -4265,6 +4273,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/afinn-165": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-1.0.4.tgz",
+      "integrity": "sha512-7+Wlx3BImrK0HiG6y3lU4xX7SpBPSSu8T9iguPMlaueRFxjbYwAQrp9lqZUuFikqKbd/en8lVREILvP2J80uJA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "license": "MIT",
@@ -4370,6 +4387,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/apparatus": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
+      "integrity": "sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==",
+      "dependencies": {
+        "sylvester": ">= 0.0.8"
+      },
+      "engines": {
+        "node": ">=0.2.6"
       }
     },
     "node_modules/arg": {
@@ -17110,6 +17138,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/natural": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/natural/-/natural-5.2.3.tgz",
+      "integrity": "sha512-fsGGpbU15YBc2oQCEsi0t7ZeF3VmKyxDhgWucQTPk4zaDFzeZtquRbZt4xlznN2ZUlH88215HcThMYaDHFM48Q==",
+      "dependencies": {
+        "afinn-165": "^1.0.2",
+        "apparatus": "^0.0.10",
+        "safe-stable-stringify": "^2.2.0",
+        "sylvester": "^0.0.12",
+        "underscore": "^1.9.1",
+        "wordnet-db": "^3.1.11"
+      },
+      "engines": {
+        "node": ">=0.4.10"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "license": "MIT"
@@ -18810,6 +18854,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.0.tgz",
+      "integrity": "sha512-eehKHKpab6E741ud7ZIMcXhKcP6TSIezPkNZhy5U8xC6+VvrRdUA2tMgxGxaGl4cz7c2Ew5+mg5+wNB16KQqrA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
@@ -19731,6 +19783,14 @@
       "version": "2.4.0",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/sylvester": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.12.tgz",
+      "integrity": "sha512-SzRP5LQ6Ts2G5NyAa/jg16s8e3R7rfdFjizy1zeoecYWw+nGL+YA1xZvW/+iJmidBGSdLkuvdwTYEyJEb+EiUw==",
+      "engines": {
+        "node": ">=0.2.6"
+      }
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
@@ -20842,6 +20902,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordnet-db": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/wordnet-db/-/wordnet-db-3.1.14.tgz",
+      "integrity": "sha512-zVyFsvE+mq9MCmwXUWHIcpfbrHHClZWZiVOzKSxNJruIcFn2RbY55zkhiAMMxM8zCVSmtNiViq8FsAZSFpMYag==",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "license": "MIT"
@@ -21049,6 +21117,7 @@
         "@koa/router": "^12.0.0",
         "@types/koa__router": "^12.0.0",
         "@types/koa-bodyparser": "^4.3.8",
+        "@types/natural": "^5.1.1",
         "@webcomponents/catalog-api": "0.0.0",
         "@webcomponents/custom-elements-manifest-tools": "0.0.0",
         "custom-elements-manifest": "^2.0.0",
@@ -21056,6 +21125,7 @@
         "firebase-admin": "^11.0.0",
         "graphql-helix": "^1.13.0",
         "koa-bodyparser": "^4.3.0",
+        "natural": "^5.2.3",
         "node-fetch": "^3.2.3",
         "npm-registry-fetch": "^13.1.0",
         "semver": "^7.3.7"
@@ -23742,6 +23812,14 @@
     "@types/minimatch": {
       "version": "3.0.5"
     },
+    "@types/natural": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/natural/-/natural-5.1.1.tgz",
+      "integrity": "sha512-BqppT8eHJvc0pN81XE7Rx5P8Osg1TSnOx3iwzLWImIO+6DwNUfpKR20tvg713O2eqHoxLcqrBaL10foo1mw/Xw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "18.8.3"
     },
@@ -23983,6 +24061,7 @@
         "@koa/router": "^12.0.0",
         "@types/koa__router": "^12.0.0",
         "@types/koa-bodyparser": "^4.3.8",
+        "@types/natural": "*",
         "@types/node": "^18.0.6",
         "@types/npm-registry-fetch": "^8.0.0",
         "@types/source-map-support": "^0.5.3",
@@ -23994,6 +24073,7 @@
         "firebase-tools": "^11.3.0",
         "graphql-helix": "^1.13.0",
         "koa-bodyparser": "^4.3.0",
+        "natural": "^5.2.3",
         "node-fetch": "^3.2.3",
         "npm-registry-fetch": "^13.1.0",
         "semver": "^7.3.7"
@@ -24142,6 +24222,11 @@
       "version": "8.2.0",
       "dev": true
     },
+    "afinn-165": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-1.0.4.tgz",
+      "integrity": "sha512-7+Wlx3BImrK0HiG6y3lU4xX7SpBPSSu8T9iguPMlaueRFxjbYwAQrp9lqZUuFikqKbd/en8lVREILvP2J80uJA=="
+    },
     "agent-base": {
       "version": "6.0.2",
       "requires": {
@@ -24204,6 +24289,14 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "apparatus": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
+      "integrity": "sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==",
+      "requires": {
+        "sylvester": ">= 0.0.8"
       }
     },
     "arg": {
@@ -32692,6 +32785,19 @@
         }
       }
     },
+    "natural": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/natural/-/natural-5.2.3.tgz",
+      "integrity": "sha512-fsGGpbU15YBc2oQCEsi0t7ZeF3VmKyxDhgWucQTPk4zaDFzeZtquRbZt4xlznN2ZUlH88215HcThMYaDHFM48Q==",
+      "requires": {
+        "afinn-165": "^1.0.2",
+        "apparatus": "^0.0.10",
+        "safe-stable-stringify": "^2.2.0",
+        "sylvester": "^0.0.12",
+        "underscore": "^1.9.1",
+        "wordnet-db": "^3.1.11"
+      }
+    },
     "natural-compare": {
       "version": "1.4.0"
     },
@@ -33754,6 +33860,11 @@
         "is-regex": "^1.1.4"
       }
     },
+    "safe-stable-stringify": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.0.tgz",
+      "integrity": "sha512-eehKHKpab6E741ud7ZIMcXhKcP6TSIezPkNZhy5U8xC6+VvrRdUA2tMgxGxaGl4cz7c2Ew5+mg5+wNB16KQqrA=="
+    },
     "safer-buffer": {
       "version": "2.1.2"
     },
@@ -34388,6 +34499,11 @@
           "dev": true
         }
       }
+    },
+    "sylvester": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.12.tgz",
+      "integrity": "sha512-SzRP5LQ6Ts2G5NyAa/jg16s8e3R7rfdFjizy1zeoecYWw+nGL+YA1xZvW/+iJmidBGSdLkuvdwTYEyJEb+EiUw=="
     },
     "symbol-observable": {
       "version": "4.0.0"
@@ -35081,6 +35197,11 @@
     },
     "word-wrap": {
       "version": "1.2.3"
+    },
+    "wordnet-db": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/wordnet-db/-/wordnet-db-3.1.14.tgz",
+      "integrity": "sha512-zVyFsvE+mq9MCmwXUWHIcpfbrHHClZWZiVOzKSxNJruIcFn2RbY55zkhiAMMxM8zCVSmtNiViq8FsAZSFpMYag=="
     },
     "wordwrap": {
       "version": "1.0.0"

--- a/packages/catalog-api/src/lib/schema.graphql
+++ b/packages/catalog-api/src/lib/schema.graphql
@@ -8,27 +8,8 @@ type Query {
   """
   Queries custom elements in the entire catalog, from the latest version of each
   package.
-
-  Eventually this will have more query parameters, and use some sort of ranking
-  algorithm, otherwise the order will just be defined by the database
-  implementation.
-
-  NOT IMPLEMENTED
-  DO_NOT_LAUNCH
   """
-  elements(distTag: String = "latest", limit: Int): [CustomElement!]!
-
-  """
-  Retrieves the custom element data for a single element.
-
-  NOT IMPLEMENTED
-  DO_NOT_LAUNCH
-  """
-  element(
-    packageName: String!
-    elementName: String!
-    tag: String = "latest"
-  ): CustomElement
+  elements(query: String, limit: Int): [CustomElement!]!
 }
 
 type Mutation {

--- a/packages/catalog-server/package.json
+++ b/packages/catalog-server/package.json
@@ -84,6 +84,7 @@
     "@koa/router": "^12.0.0",
     "@types/koa__router": "^12.0.0",
     "@types/koa-bodyparser": "^4.3.8",
+    "@types/natural": "^5.1.1",
     "@webcomponents/catalog-api": "0.0.0",
     "@webcomponents/custom-elements-manifest-tools": "0.0.0",
     "custom-elements-manifest": "^2.0.0",
@@ -91,6 +92,7 @@
     "firebase-admin": "^11.0.0",
     "graphql-helix": "^1.13.0",
     "koa-bodyparser": "^4.3.0",
+    "natural": "^5.2.3",
     "node-fetch": "^3.2.3",
     "npm-registry-fetch": "^13.1.0",
     "semver": "^7.3.7"

--- a/packages/catalog-server/src/lib/catalog.ts
+++ b/packages/catalog-server/src/lib/catalog.ts
@@ -272,8 +272,7 @@ export class Catalog {
 
     console.log('Writing custom elements...');
     await this.#repository.writeCustomElements(
-      packageName,
-      version,
+      packageVersionMetadata,
       customElements,
       versionDistTags,
       author
@@ -307,11 +306,21 @@ export class Catalog {
     return this.#repository.getPackageVersion(packageName, version);
   }
 
+  /**
+   * Gets the custom elements for a package
+   */
   async getCustomElements(
     packageName: string,
     version: string,
     tagName: string | undefined
   ): Promise<Array<CustomElement>> {
     return this.#repository.getCustomElements(packageName, version, tagName);
+  }
+
+  async queryElements({query, limit}: {query?: string; limit?: number}) {
+    // TODO (justinfagnani): The catalog should parse out GitHub-style search
+    // operators (like "author:yogibear") and pass structured + text queries
+    // to the repository
+    return this.#repository.queryElements({query, limit});
   }
 }

--- a/packages/catalog-server/src/lib/firestore/firestore-repository.ts
+++ b/packages/catalog-server/src/lib/firestore/firestore-repository.ts
@@ -511,7 +511,6 @@ export class FirestoreRepository implements Repository {
       if (queryTerms.length > 10) {
         queryTerms.length = 10;
       }
-      console.log('queryTerms', queryTerms);
       dbQuery = dbQuery.where('searchTerms', 'array-contains-any', queryTerms);
     }
 

--- a/packages/catalog-server/src/lib/firestore/firestore-repository.ts
+++ b/packages/catalog-server/src/lib/firestore/firestore-repository.ts
@@ -325,7 +325,10 @@ export class FirestoreRepository implements Repository {
           ...descriptionStems,
           ...summaryStems,
           ...tagNameParts,
-          tagName
+          tagName,
+          // TODO (justinfagnani): tokenizing the package name is temporary
+          // until we don't tokenize the *entire* query
+          ...natural.PorterStemmer.tokenizeAndStem(packageName),
         ]),
       ];
 
@@ -508,6 +511,7 @@ export class FirestoreRepository implements Repository {
       if (queryTerms.length > 10) {
         queryTerms.length = 10;
       }
+      console.log('queryTerms', queryTerms);
       dbQuery = dbQuery.where('searchTerms', 'array-contains-any', queryTerms);
     }
 

--- a/packages/catalog-server/src/lib/firestore/firestore-repository.ts
+++ b/packages/catalog-server/src/lib/firestore/firestore-repository.ts
@@ -290,13 +290,12 @@ export class FirestoreRepository implements Repository {
   }
 
   async writeCustomElements(
-    packageVersionMetadata: Version,
+    {name: packageName, version, description}: Version,
     customElements: CustomElementInfo[],
     distTags: string[],
     author: string
   ): Promise<void> {
     // Store custom elements data in subcollection
-    const {name: packageName, version, description} = packageVersionMetadata;
     const versionRef = this.getPackageVersionRef(packageName, version);
     const customElementsRef = versionRef.collection('customElements');
     const isLatest = distTags.includes('latest');
@@ -326,6 +325,7 @@ export class FirestoreRepository implements Repository {
           ...descriptionStems,
           ...summaryStems,
           ...tagNameParts,
+          tagName
         ]),
       ];
 

--- a/packages/catalog-server/src/lib/firestore/package-version-converter.ts
+++ b/packages/catalog-server/src/lib/firestore/package-version-converter.ts
@@ -39,6 +39,7 @@ export const packageVersionConverter: FirestoreDataConverter<PackageVersion> = {
         customElementsManifest: packageVersion.customElementsManifest,
         description: packageVersion.description,
         distTags: packageVersion.distTags,
+        isLatest: packageVersion.distTags.includes('latest'),
         homepage: packageVersion.homepage,
         lastUpdate: packageVersion.lastUpdate,
         status: packageVersion.status,

--- a/packages/catalog-server/src/lib/graphql.ts
+++ b/packages/catalog-server/src/lib/graphql.ts
@@ -7,7 +7,13 @@
 import {readFile} from 'fs/promises';
 import {createRequire} from 'module';
 import {makeExecutableSchema} from '@graphql-tools/schema';
-import {isReadablePackage, isReadablePackageVersion, PackageInfo, Resolvers} from '@webcomponents/catalog-api/lib/schema.js';
+import {
+  CustomElement,
+  isReadablePackage,
+  isReadablePackageVersion,
+  PackageInfo,
+  Resolvers,
+} from '@webcomponents/catalog-api/lib/schema.js';
 import {Catalog} from './catalog.js';
 
 const require = createRequire(import.meta.url);
@@ -25,14 +31,17 @@ export const makeExecutableCatalogSchema = async (catalog: Catalog) => {
   // an explanation of the role of resolvers in performing GraphQL queries.
   const resolvers: Resolvers = {
     Query: {
-      async package(_parent, {packageName}: {packageName: string}): Promise<PackageInfo | null> {
+      async package(
+        _parent,
+        {packageName}: {packageName: string}
+      ): Promise<PackageInfo | null> {
         console.log('query package', packageName);
         const packageInfo = await catalog.getPackageInfo(packageName);
         if (packageInfo === undefined) {
           console.log(`package ${packageName} not found in db, importing`);
           let result;
           try {
-             result = await catalog.importPackage(packageName);
+            result = await catalog.importPackage(packageName);
           } catch (e) {
             console.error(e);
             throw e;
@@ -52,6 +61,13 @@ export const makeExecutableCatalogSchema = async (catalog: Catalog) => {
           console.log(`package ${packageName} found in db and not readable`);
           return null;
         }
+      },
+      async elements(_parent, {query, limit}): Promise<Array<CustomElement>> {
+        console.log('query elements', {query, limit});
+        return catalog.queryElements({
+          query: query ?? undefined,
+          limit: limit ?? 25,
+        });
       },
     },
     PackageInfo: {
@@ -75,7 +91,10 @@ export const makeExecutableCatalogSchema = async (catalog: Catalog) => {
           distTags?.find((distTag) => distTag.tag === versionOrTag)?.version ??
           versionOrTag;
 
-        const packageVersion = await catalog.getPackageVersion(packageInfo.name, version);
+        const packageVersion = await catalog.getPackageVersion(
+          packageInfo.name,
+          version
+        );
         if (packageVersion === undefined) {
           throw new Error(`tag ${packageInfo.name}@${versionOrTag} not found`);
         }

--- a/packages/catalog-server/src/lib/graphql.ts
+++ b/packages/catalog-server/src/lib/graphql.ts
@@ -63,7 +63,6 @@ export const makeExecutableCatalogSchema = async (catalog: Catalog) => {
         }
       },
       async elements(_parent, {query, limit}): Promise<Array<CustomElement>> {
-        console.log('query elements', {query, limit});
         return catalog.queryElements({
           query: query ?? undefined,
           limit: limit ?? 25,

--- a/packages/catalog-server/src/lib/repository.ts
+++ b/packages/catalog-server/src/lib/repository.ts
@@ -13,7 +13,10 @@ import type {
   ValidationProblem,
 } from '@webcomponents/catalog-api/lib/schema';
 import type {CustomElementInfo} from '@webcomponents/custom-elements-manifest-tools';
-import type {Package} from '@webcomponents/custom-elements-manifest-tools/lib/npm.js';
+import type {
+  Package,
+  Version,
+} from '@webcomponents/custom-elements-manifest-tools/lib/npm.js';
 
 /**
  * Interface for a database that stores package and custom element data.
@@ -91,8 +94,7 @@ export interface Repository {
   ): Promise<void>;
 
   writeCustomElements(
-    packageName: string,
-    version: string,
+    packageVersionMetadata: Version,
     customElements: CustomElementInfo[],
     distTags: string[],
     author: string
@@ -105,7 +107,15 @@ export interface Repository {
     packageName: string,
     version: string,
     tagName?: string
-  ): Promise<CustomElement[]>;
+  ): Promise<Array<CustomElement>>;
+
+  queryElements({
+    query,
+    limit,
+  }: {
+    query?: string;
+    limit?: number;
+  }): Promise<Array<CustomElement>>;
 
   writeProblems(
     packageName: string,

--- a/packages/catalog-server/src/test/lib/catalog_test.ts
+++ b/packages/catalog-server/src/test/lib/catalog_test.ts
@@ -31,7 +31,6 @@ const TEST_SEQUENCE_ONE = 'test-data-1';
 // Other tests than can run independently
 const TEST_SEQUENCE_TWO = 'test-data-2';
 
-
 test('Imports a package with no problems', async () => {
   const packageName = 'test-1';
   const version = '0.0.0';
@@ -106,20 +105,35 @@ test('Full text search', async () => {
   const catalog = new Catalog({files, repository});
 
   // Use a term in the package description - it should match all elements
-  const resultOne = await catalog.queryElements({
-    query: 'cool',
-    limit: 10
-  });
-  assert.ok(resultOne);
-  assert.equal(resultOne.length, 2);
+  let result = await catalog.queryElements({query: 'cool'});
+  assert.equal(result.length, 2);
 
   // Use a term in an element description
-  const resultTwo = await catalog.queryElements({
-    query: 'incredible',
-    limit: 10
-  });
-  assert.ok(resultTwo);
-  assert.equal(resultTwo.length, 1);
+  result = await catalog.queryElements({query: 'incredible'});
+  assert.equal(result.length, 1);
+
+  // Use a term not found
+  result = await catalog.queryElements({query: 'jandgslwijd'});
+  assert.equal(result.length, 0);
+
+  // Use an element name
+  result = await catalog.queryElements({query: '"foo-element"'});
+  // TODO (justinfagnani): this isn't what we want. We really just want
+  // The element <foo-element> to be returned, but the tokenizer we're
+  // using is splitting "foo-element" into ["foo", "element"] and "element"
+  // is matching against bar-element's search terms.
+  // If we keep our own search index, we'll want to use or write a tokenizer
+  // that preserves quoted sections for exact matches:
+  // http://naturalnode.github.io/natural/Tokenizers.html
+  assert.equal(result.length, 2);
+
+  // Use part of an element name
+  result = await catalog.queryElements({query: 'element'});
+  assert.equal(result.length, 2);
+
+  // Use a package name
+  result = await catalog.queryElements({query: 'test-1'});
+  assert.equal(result.length, 2);
 });
 
 test('Gets package version data from imported package', async () => {

--- a/packages/catalog-server/test/test-packages/test-1/0.0.0/custom-elements.json
+++ b/packages/catalog-server/test/test-packages/test-1/0.0.0/custom-elements.json
@@ -1,5 +1,6 @@
 {
   "schemaVersion": "1.0.0",
+  "description": "A set of cool elements",
   "modules": [
     {
       "kind": "javascript-module",
@@ -18,14 +19,39 @@
           "declaration": {
             "name": "FooElement"
           }
+        },
+        {
+          "kind": "js",
+          "name": "BarElement",
+          "declaration": {
+            "name": "BarElement"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "bar-element",
+          "declaration": {
+            "name": "BarElement"
+          }
         }
       ],
       "declarations": [
         {
           "kind": "class",
           "customElement": true,
-          "tagName": "my-element",
+          "tagName": "foo-element",
           "name": "FooElement",
+          "description": "A incredible element",
+          "superclass": {
+            "name": "HTMLElement"
+          }
+        },
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "bar-element",
+          "name": "BarElement",
+          "description": "An amazing element",
           "superclass": {
             "name": "HTMLElement"
           }

--- a/packages/catalog-server/test/test-packages/test-1/0.0.0/package.json
+++ b/packages/catalog-server/test/test-packages/test-1/0.0.0/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test-1",
   "version": "0.0.0",
+  "description": "A set of cool elements",
   "customElements": "custom-elements.json"
 }

--- a/packages/catalog-server/test/test-packages/test-1/1.0.0/custom-elements.json
+++ b/packages/catalog-server/test/test-packages/test-1/1.0.0/custom-elements.json
@@ -1,5 +1,6 @@
 {
   "schemaVersion": "1.0.0",
+  "description": "A set of cool elements",
   "modules": [
     {
       "kind": "javascript-module",
@@ -18,14 +19,37 @@
           "declaration": {
             "name": "FooElement"
           }
+        },
+        {
+          "kind": "js",
+          "name": "BarElement",
+          "declaration": {
+            "name": "BarElement"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "bar-element",
+          "declaration": {
+            "name": "BarElement"
+          }
         }
       ],
       "declarations": [
         {
           "kind": "class",
           "customElement": true,
-          "tagName": "my-element",
+          "tagName": "bar-element",
           "name": "FooElement",
+          "superclass": {
+            "name": "HTMLElement"
+          }
+        },
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "bar-element",
+          "name": "BarElement",
           "superclass": {
             "name": "HTMLElement"
           }

--- a/packages/catalog-server/test/test-packages/test-1/1.0.0/package.json
+++ b/packages/catalog-server/test/test-packages/test-1/1.0.0/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test-1",
   "version": "1.0.0",
+  "description": "A set of cool elements",
   "customElements": "custom-elements.json"
 }

--- a/packages/custom-elements-manifest-tools/src/lib/npm.ts
+++ b/packages/custom-elements-manifest-tools/src/lib/npm.ts
@@ -38,16 +38,16 @@ export interface Package {
 export interface Version {
   name: string;
   version: string;
-  description: string;
+  description?: string;
   dist: Dist;
   type?: 'module' | 'commonjs';
-  main: string;
+  main?: string;
   module?: string;
 
   author?: {name: string};
   homepage?: string;
 
-  repository: {
+  repository?: {
     type: 'git' | 'svn';
     url: string;
   };

--- a/packages/custom-elements-manifest-tools/src/test/local-fs-package-files.ts
+++ b/packages/custom-elements-manifest-tools/src/test/local-fs-package-files.ts
@@ -51,7 +51,7 @@ export class LocalFsPackageFiles implements PackageFiles {
       modified: now,
       // ...Object.fromEntries(this.publishedVersions.map((v) => [v, now])),
     };
-    let description!: string;
+    let description: string | undefined;
     let foundLatest = false;
     await Promise.all(
       this.publishedVersions.map(async (v) => {


### PR DESCRIPTION
This implements full-text search by:
1. Stemming a number of fields and storing the results in an array field in CustomElement documents
2. Stemming the user's text query
3. Retrieving elements with a collectionGroup query across the `customElement` collections and filtering with an `array-contains-any` operator

I'm using https://github.com/NaturalNode/natural for stemming. It looks well maintained and thorough compared to other libraries.

The fields currently indexed are:
- package description
- element summary
- element description
- A split of the element name by `-`, using segments more than 3 characters long (to get `button` from `sl-button`, etc).

Builds on https://github.com/webcomponents/webcomponents.org/pull/1364. We need to fix https://github.com/webcomponents/webcomponents.org/issues/1351 to ensure that queries are confined to a single namespace.