### PR TITLE
Add 'isLatest' field to reduce array-contains uses

### DIFF
--- a/packages/catalog-server/src/lib/firestore/package-version-converter.ts
+++ b/packages/catalog-server/src/lib/firestore/package-version-converter.ts
@@ -39,6 +39,7 @@ export const packageVersionConverter: FirestoreDataConverter<PackageVersion> = {
         customElementsManifest: packageVersion.customElementsManifest,
         description: packageVersion.description,
         distTags: packageVersion.distTags,
+        isLatest: packageVersion.distTags.includes('latest'),
         homepage: packageVersion.homepage,
         lastUpdate: packageVersion.lastUpdate,
         status: packageVersion.status,


### PR DESCRIPTION
This denormalizes the 'latest' dist-tag to an `isLatest` field on PackageVersion and CustomElement. `'latest'` will by far be the most common dist-tag to search for and this will be marginally more efficient, but more importantly it will make other queries that rely on array-contains, like full-text search, easier.

Part of #1363 