### PR TITLE
Add a stub search UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3205,6 +3205,17 @@
       "version": "2.4.0",
       "license": "0BSD"
     },
+    "node_modules/@koa/cors": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-4.0.0.tgz",
+      "integrity": "sha512-Y4RrbvGTlAaa04DBoPBWJqDR5gPj32OOz827ULXfgB1F7piD1MB/zwn8JR2LAnvdILhxUbXbkXGWuNVsFuVFCQ==",
+      "dependencies": {
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/@koa/router": {
       "version": "12.0.0",
       "license": "MIT",
@@ -3655,6 +3666,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/koa__cors": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.3.0.tgz",
+      "integrity": "sha512-FUN8YxcBakIs+walVe3+HcNP+Bxd0SB8BJHBWkglZ5C1XQWljlKcEFDG/dPiCIqwVCUbc5X0nYDlH62uEhdHMA==",
+      "dependencies": {
+        "@types/koa": "*"
+      }
+    },
     "node_modules/@types/koa__router": {
       "version": "12.0.0",
       "license": "MIT",
@@ -4007,6 +4026,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@urql/core": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-3.0.4.tgz",
+      "integrity": "sha512-7c12WLHKjmxcxM8nrVdtaYHQnS0WXSfYCf5lg28eRL2ySbo2rOPINLblblDo8UwGTeyrNzjSRVd0I0NlTN6XTA==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "wonka": "^6.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@web/config-loader": {
@@ -14326,7 +14357,8 @@
     },
     "node_modules/graphql": {
       "version": "16.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -20895,6 +20927,11 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/wonka": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.0.tgz",
+      "integrity": "sha512-VgiMCz7BXOiDbgpVhf5iNhK7hurteY5Jv0fDJewUkY0s4fbxQD2iKqfGxNXNTwp2v3bgT8QVu2l5H7YdkZ5WIA=="
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "license": "MIT",
@@ -21156,6 +21193,9 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@urql/core": "^3.0.4",
+        "@webcomponents/catalog-api": "^0.0.0",
+        "graphql": "^16.6.0",
         "lit": "^2.3.1",
         "lit-analyzer": "^1.2.1"
       }
@@ -21165,7 +21205,8 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@11ty/eleventy": "^1.0.2"
+        "@11ty/eleventy": "^1.0.2",
+        "@webcomponents/internal-site-server": "^0.0.0"
       }
     },
     "packages/site-server": {
@@ -21174,8 +21215,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "^3.7.0",
+        "@koa/cors": "^4.0.0",
         "@koa/router": "^12.0.0",
         "@types/koa": "^2.13.5",
+        "@types/koa__cors": "^3.3.0",
         "@types/koa__router": "^12.0.0",
         "@types/koa-conditional-get": "^2.0.0",
         "@types/koa-etag": "^3.0.0",
@@ -23421,6 +23464,14 @@
         }
       }
     },
+    "@koa/cors": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-4.0.0.tgz",
+      "integrity": "sha512-Y4RrbvGTlAaa04DBoPBWJqDR5gPj32OOz827ULXfgB1F7piD1MB/zwn8JR2LAnvdILhxUbXbkXGWuNVsFuVFCQ==",
+      "requires": {
+        "vary": "^1.1.2"
+      }
+    },
     "@koa/router": {
       "version": "12.0.0",
       "requires": {
@@ -23746,6 +23797,14 @@
         "@types/node": "*"
       }
     },
+    "@types/koa__cors": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.3.0.tgz",
+      "integrity": "sha512-FUN8YxcBakIs+walVe3+HcNP+Bxd0SB8BJHBWkglZ5C1XQWljlKcEFDG/dPiCIqwVCUbc5X0nYDlH62uEhdHMA==",
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
     "@types/koa__router": {
       "version": "12.0.0",
       "requires": {
@@ -23974,6 +24033,15 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@urql/core": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-3.0.4.tgz",
+      "integrity": "sha512-7c12WLHKjmxcxM8nrVdtaYHQnS0WXSfYCf5lg28eRL2ySbo2rOPINLblblDo8UwGTeyrNzjSRVd0I0NlTN6XTA==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "wonka": "^6.0.0"
+      }
+    },
     "@web/config-loader": {
       "version": "0.1.3",
       "requires": {
@@ -24061,7 +24129,7 @@
         "@koa/router": "^12.0.0",
         "@types/koa__router": "^12.0.0",
         "@types/koa-bodyparser": "^4.3.8",
-        "@types/natural": "*",
+        "@types/natural": "^5.1.1",
         "@types/node": "^18.0.6",
         "@types/npm-registry-fetch": "^8.0.0",
         "@types/source-map-support": "^0.5.3",
@@ -24092,6 +24160,9 @@
     "@webcomponents/internal-site-client": {
       "version": "file:packages/site-client",
       "requires": {
+        "@urql/core": "^3.0.4",
+        "@webcomponents/catalog-api": "^0.0.0",
+        "graphql": "^16.6.0",
         "lit": "^2.3.1",
         "lit-analyzer": "^1.2.1"
       }
@@ -24099,15 +24170,18 @@
     "@webcomponents/internal-site-content": {
       "version": "file:packages/site-content",
       "requires": {
-        "@11ty/eleventy": "^1.0.2"
+        "@11ty/eleventy": "^1.0.2",
+        "@webcomponents/internal-site-server": "^0.0.0"
       }
     },
     "@webcomponents/internal-site-server": {
       "version": "file:packages/site-server",
       "requires": {
         "@apollo/client": "^3.7.0",
+        "@koa/cors": "^4.0.0",
         "@koa/router": "^12.0.0",
         "@types/koa": "^2.13.5",
+        "@types/koa__cors": "^3.3.0",
         "@types/koa__router": "^12.0.0",
         "@types/koa-conditional-get": "^2.0.0",
         "@types/koa-etag": "^3.0.0",
@@ -30963,7 +31037,9 @@
       "version": "1.0.4"
     },
     "graphql": {
-      "version": "16.6.0"
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
     },
     "graphql-config": {
       "version": "4.3.6",
@@ -35194,6 +35270,11 @@
         "assert-never": "^1.2.1",
         "babel-walk": "3.0.0-canary-5"
       }
+    },
+    "wonka": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.0.tgz",
+      "integrity": "sha512-VgiMCz7BXOiDbgpVhf5iNhK7hurteY5Jv0fDJewUkY0s4fbxQD2iKqfGxNXNTwp2v3bgT8QVu2l5H7YdkZ5WIA=="
     },
     "word-wrap": {
       "version": "1.2.3"

--- a/packages/catalog-server/src/lib/server.ts
+++ b/packages/catalog-server/src/lib/server.ts
@@ -8,6 +8,7 @@ import {readFile} from 'fs/promises';
 import {fileURLToPath} from 'url';
 
 import Koa from 'koa';
+import cors from '@koa/cors';
 import Router from '@koa/router';
 import {
   getGraphQLParameters,
@@ -163,6 +164,7 @@ export const makeServer = async () => {
     `;
   });
 
+  app.use(cors());
   app.use(router.routes());
   app.use(router.allowedMethods());
   return app;

--- a/packages/site-client/package.json
+++ b/packages/site-client/package.json
@@ -23,7 +23,7 @@
       ]
     },
     "build:dev": {
-      "command": "find src -name \"*.ts\" | xargs esbuild --format=esm --target=es2022 --color --outdir=lib",
+      "command": "find src -name \"*.ts\" | xargs esbuild --color --outdir=lib",
       "files": [
         "src/**/*.ts"
       ],
@@ -33,7 +33,7 @@
       "clean": "if-file-deleted"
     },
     "build:prod": {
-      "command": "esbuild --format=esm --target=es2022 --color --outdir=bundled --bundle --splitting --minify src/entrypoints/*.ts",
+      "command": "esbuild --color --outdir=bundled --bundle --splitting --minify src/entrypoints/*.ts",
       "files": [
         "src/**/*.ts"
       ],
@@ -66,6 +66,9 @@
     }
   },
   "dependencies": {
+    "@urql/core": "^3.0.4",
+    "@webcomponents/catalog-api": "^0.0.0",
+    "graphql": "^16.6.0",
     "lit": "^2.3.1",
     "lit-analyzer": "^1.2.1"
   }

--- a/packages/site-client/src/components/wco-catalog-search.ts
+++ b/packages/site-client/src/components/wco-catalog-search.ts
@@ -4,28 +4,87 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- import {html, css, LitElement} from 'lit';
- import {customElement} from 'lit/decorators.js';
- 
- @customElement('wco-catalog-search')
- export class WCOCatalogSearch extends LitElement {
-   static styles = css`
-     :host {
-       display: flex;
-       align-items: center;
-     }
-   `;
- 
-   render() {
-     return html`
-       Search: <input>
-     `;
-   }
- }
- 
- declare global {
-   interface HTMLElementTagNameMap {
-     'wco-catalog-search': WCOCatalogSearch;
-   }
- }
- 
+import {html, css, LitElement} from 'lit';
+import {customElement, query, state} from 'lit/decorators.js';
+import {gql, createClient, defaultExchanges} from '@urql/core';
+import type {CustomElement} from '@webcomponents/catalog-api/lib/schema.js';
+
+import './wco-element-card.js';
+
+const client = createClient({
+  // TODO (justinfagnani): get this URL from server
+  url: 'http://localhost:6451/graphql',
+  exchanges: defaultExchanges,
+});
+
+const elementsQuery = gql`
+  query Elements($query: String) {
+    elements(query: $query, limit: 16) {
+      tagName
+      package
+      version
+      className
+    }
+  }
+`;
+
+@customElement('wco-catalog-search')
+export class WCOCatalogSearch extends LitElement {
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    div {
+      display: grid;
+      grid-template-columns: repeat(4, 200px);
+      grid-template-rows: auto;
+      grid-auto-columns: 200px;
+      grid-auto-rows: 200px;
+      gap: 8px;
+    }
+  `;
+
+  @query('input')
+  private _search!: HTMLInputElement;
+
+  @state()
+  private _elements: Array<CustomElement> | undefined;
+
+  render() {
+    return html`
+      <p>Search: <input id="search" @change=${this._onChange} /></p>
+      <div>
+        ${this._elements?.map(
+          (e) => html`<wco-element-card .element=${e}></wco-element-card>`
+        )}
+      </div>
+    `;
+  }
+
+  protected firstUpdated() {
+    // TODO (justinfagnani): we may want to use a router (and write the search
+    // to the URL) but this is easy for now.
+    const urlQuery = new URLSearchParams(window.location.search).get('query');
+    if (urlQuery) {
+      this._search.value = urlQuery;
+      this._onChange();
+    }
+  }
+
+  async _onChange() {
+    const searchText = this._search.value;
+    const result = await client
+      .query(elementsQuery, {query: searchText})
+      .toPromise();
+    this._elements = result.data?.elements;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'wco-catalog-search': WCOCatalogSearch;
+  }
+}

--- a/packages/site-client/src/components/wco-element-card.ts
+++ b/packages/site-client/src/components/wco-element-card.ts
@@ -74,7 +74,7 @@ export class WCOElementCard extends LitElement {
     const packageName = this.element.package;
     const tagName = this.element.tagName ?? '';
 
-    // Generate one or two-letter initials starting after what we assyme is
+    // Generate one or two-letter initials starting after what we assume is
     // the tagname prefix. This is a stand-in for icons, which aren't
     // represented in the CE manifest yet.
     const tagNameParts = tagName.split('-');

--- a/packages/site-client/src/components/wco-element-card.ts
+++ b/packages/site-client/src/components/wco-element-card.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {html, css, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import type {CustomElement} from '@webcomponents/catalog-api/lib/schema.js';
+
+@customElement('wco-element-card')
+export class WCOElementCard extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      /* TODO (justinfagnani): who controls the size? This or the containing
+         grid? */
+      width: 200px;
+      height: 200px;
+      border: solid 1px #444;
+      border-radius: 8px;
+      padding: 4px;
+      overflow: clip;
+      box-sizing: border-box;
+      cursor: pointer;
+    }
+
+    :host(:hover) {
+      box-shadow: 5px 5px 10px gray;
+    }
+
+    a#card-link {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      color: inherit;
+      text-decoration: none;
+      height: 100%;
+    }
+
+    h2 {
+      margin: 0;
+      font-size: 1em;
+    }
+
+    h3 {
+      margin: 0;
+      font-size: 1em;
+      color: #888;
+      font-weight: normal;
+    }
+
+    #initials {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 64px;
+      height: 64px;
+      border-radius: 10%;
+      color: white;
+      background: #d6543d;
+      font-size: 2em;
+      font-weight: bold;
+    }
+  `;
+
+  @property()
+  private element?: CustomElement;
+
+  render() {
+    if (this.element === undefined) {
+      return undefined;
+    }
+    const packageName = this.element.package;
+    const tagName = this.element.tagName ?? '';
+
+    // Generate one or two-letter initials starting after what we assyme is
+    // the tagname prefix. This is a stand-in for icons, which aren't
+    // represented in the CE manifest yet.
+    const tagNameParts = tagName.split('-');
+    let initials = (tagNameParts[1]?.[0] ?? '') + (tagNameParts[2]?.[0] ?? '');
+    initials = initials.toUpperCase();
+
+    return html`
+      <a id="card-link" href="/catalog/element/${packageName}/${tagName}">
+        <div id="initials">${initials}</div>
+        <h2>&lt;${tagName}&gt;</h2>
+        <h3>${packageName}</h3>
+        <div>${this.element?.author}</div>
+      </a>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'wco-element-card': WCOElementCard;
+  }
+}

--- a/packages/site-client/tsconfig.json
+++ b/packages/site-client/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "noEmit": true,
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
+    "useDefineForClassFields": false
   },
   "include": ["src/**/*.ts"],
   "exclude": []

--- a/packages/site-server/package.json
+++ b/packages/site-server/package.json
@@ -43,8 +43,10 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.0",
+    "@koa/cors": "^4.0.0",
     "@koa/router": "^12.0.0",
     "@types/koa": "^2.13.5",
+    "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^12.0.0",
     "@types/koa-conditional-get": "^2.0.0",
     "@types/koa-etag": "^3.0.0",

--- a/packages/site-server/src/templates/base.ts
+++ b/packages/site-server/src/templates/base.ts
@@ -23,6 +23,11 @@ export const renderPage = (data: {
       href="https://fonts.googleapis.com/css?family=Material+Icons&display=block"
       rel="stylesheet"
     />
+    <!-- TODO (justinfagnani): only add this in dev. In prod we should have
+         compiled any process access out. DO_NOT_LAUNCH -->
+    <script>
+      window.process = {env: {NODE_ENV: 'development'}};
+    </script>
     ${(data.scripts ?? [])
       .map((s) => `<script type="module" src="${s}"></script>`)
       .join('\n')}


### PR DESCRIPTION
This is a very basic UI with one search field.

It performs a client-side GraphQL query. I used urql on the client side instead of Apollo because urql is smaller and published as standard JS modules (except for some `process.env` calls). The integration point is quite small and can be swapped out. If we keep it we need to move the client to a common location and probably want to wrap it in a controller.

There are a bunch of rough edges here intentionally. To make sharable links and edit-refresh development easier I added a `?query=` query param, but didn't yet use a router to read and write it. The styling is made to be obviously sketch-quality, but I added an "icon" to hint at what kind of presentation we might want.

Being able to show links to all elements imported in the bootstrap import uncovers some bugs - many elements display an error on their page. The Shoelace components work though.

Here's a preview:

![localhost_5450_catalog_query=button](https://user-images.githubusercontent.com/522948/196234335-a11ff80f-7cc7-4b4f-84e7-302b3655d8dd.png)
