### PR TITLE
Fix bug with storing element declaration references

### DIFF
--- a/packages/catalog-server/src/lib/firestore/firestore-repository.ts
+++ b/packages/catalog-server/src/lib/firestore/firestore-repository.ts
@@ -342,14 +342,17 @@ export class FirestoreRepository implements Repository {
         className: c.declaration.name,
         customElementExport: referenceString(
           packageName,
-          c.module,
+          c.module.path,
           c.export.name
         ),
-        declaration: referenceString(packageName, c.module, c.declaration.name),
+        declaration: referenceString(
+          packageName,
+          c.declarationReference.module ?? c.module.path,
+          c.declaration.name
+        ),
         searchTerms,
       });
     }
-
     await batch.commit();
   }
 

--- a/packages/catalog-server/test/test-packages/test-2/1.0.0/custom-elements.json
+++ b/packages/catalog-server/test/test-packages/test-2/1.0.0/custom-elements.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": "1.0.0",
+  "description": "A set of cool elements",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "foo.js",
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "foo-element",
+          "declaration": {
+            "name": "FooElement",
+            "module": "/foo-impl.js"
+          }
+        }
+      ],
+      "declarations": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "foo-impl.js",
+      "exports": [
+        {
+          "kind": "js",
+          "name": "FooElement",
+          "declaration": {
+            "name": "FooElement"
+          }
+        }
+      ],
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "foo-element",
+          "name": "FooElement",
+          "superclass": {
+            "name": "HTMLElement"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/catalog-server/test/test-packages/test-2/1.0.0/package.json
+++ b/packages/catalog-server/test/test-packages/test-2/1.0.0/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-2",
+  "version": "1.0.0",
+  "description": "A set of cool elements",
+  "customElements": "custom-elements.json"
+}

--- a/packages/custom-elements-manifest-tools/package.json
+++ b/packages/custom-elements-manifest-tools/package.json
@@ -31,7 +31,7 @@
       "clean": "if-file-deleted"
     },
     "test": {
-      "command": "NODE_OPTIONS='--enable-source-maps' uvu test \"resolve-reference_test\\.js$\"",
+      "command": "NODE_OPTIONS='--enable-source-maps' uvu test \"_test\\.js$\"",
       "dependencies": [
         "build"
       ],

--- a/packages/custom-elements-manifest-tools/package.json
+++ b/packages/custom-elements-manifest-tools/package.json
@@ -31,7 +31,7 @@
       "clean": "if-file-deleted"
     },
     "test": {
-      "command": "NODE_OPTIONS='--enable-source-maps' uvu test \"_test\\.js$\"",
+      "command": "NODE_OPTIONS='--enable-source-maps' uvu test \"resolve-reference_test\\.js$\"",
       "dependencies": [
         "build"
       ],

--- a/packages/custom-elements-manifest-tools/package.json
+++ b/packages/custom-elements-manifest-tools/package.json
@@ -26,6 +26,7 @@
         "lib/",
         "test/",
         "!test/test-data/shoelace-2.0.0-beta.83.json",
+        "!test/test-data/lion-button-0.18.1.json",
         "tsconfig.tsbuildinfo"
       ],
       "clean": "if-file-deleted"
@@ -36,7 +37,8 @@
         "build"
       ],
       "files": [
-        "test/test-data/shoelace-2.0.0-beta.83.json"
+        "test/test-data/shoelace-2.0.0-beta.83.json",
+        "test/test-data/lion-button-0.18.1.json"
       ],
       "output": []
     }

--- a/packages/custom-elements-manifest-tools/src/lib/get-custom-elements.ts
+++ b/packages/custom-elements-manifest-tools/src/lib/get-custom-elements.ts
@@ -9,6 +9,7 @@ import type {
   CustomElementExport,
   Module,
   Package,
+  Reference,
 } from 'custom-elements-manifest/schema.js';
 import {isCustomElementDeclaration} from './predicates.js';
 import {resolveReference} from './resolve-reference.js';
@@ -18,6 +19,7 @@ export type CustomElementInfo = {
   module: Module;
   export: CustomElementExport;
   declaration: CustomElementDeclaration;
+  declarationReference: Reference;
 };
 
 /**
@@ -48,6 +50,7 @@ export const getCustomElements = (
               module: mod,
               export: e,
               declaration: decl,
+              declarationReference: e.declaration,
             });
           } else {
             // This is some kind of manifest error, should we warn?

--- a/packages/custom-elements-manifest-tools/src/lib/reference-string.ts
+++ b/packages/custom-elements-manifest-tools/src/lib/reference-string.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {Module, Reference} from 'custom-elements-manifest/schema.js';
+import type {Reference} from 'custom-elements-manifest/schema.js';
 
 /**
  * Serializes a reference to a string, as used in the GraphQL API of the
@@ -15,10 +15,13 @@ import type {Module, Reference} from 'custom-elements-manifest/schema.js';
  */
 export const referenceString = (
   packageName: string,
-  mod: Module,
+  modulePath: string,
   name: string
 ) => {
-  return `${packageName}/${mod.path}#${name}`;
+  if (modulePath.startsWith('/')) {
+    modulePath = modulePath.substring(1);
+  }
+  return `${packageName}/${modulePath}#${name}`;
 };
 
 /**

--- a/packages/custom-elements-manifest-tools/src/test/lib/get-custom-elements_test.ts
+++ b/packages/custom-elements-manifest-tools/src/test/lib/get-custom-elements_test.ts
@@ -101,4 +101,22 @@ test('Get elements from Shoelace', async () => {
   assert.equal(customElements.length, 54);
 });
 
+test('Get elements from @liton/burron', async () => {
+  const manifestPath = fileURLToPath(
+    new URL('../test-data/lion-button-0.18.1.json', import.meta.url)
+  );
+  const manifestSource = await readFile(manifestPath, 'utf-8');
+  const manifest = JSON.parse(manifestSource);
+  const customElements = getCustomElements(
+    manifest,
+    '@lion/button',
+    '0.18.1'
+  );
+  assert.equal(customElements.length, 3);
+
+  const element = customElements.find((e) => e.export.name === 'lion-button-submit');
+  assert.ok(element);
+  assert.ok(element.declaration);
+});
+
 test.run();

--- a/packages/custom-elements-manifest-tools/src/test/lib/resolve-reference_test.ts
+++ b/packages/custom-elements-manifest-tools/src/test/lib/resolve-reference_test.ts
@@ -48,6 +48,42 @@ const pkg: Package = {
         },
       ],
     },
+    {
+      kind: 'javascript-module',
+      path: 'x-foo.js',
+      declarations: [],
+      exports: [
+        {
+          kind: 'custom-element-definition',
+          name: 'x-foo',
+          declaration: {
+            name: 'XFoo',
+            module: '/src/components/x-foo.js',
+          },
+        },
+      ],
+    },
+    {
+      kind: 'javascript-module',
+      path: 'src/components/x-foo.js',
+      declarations: [
+        {
+          kind: 'class',
+          name: 'XFoo',
+          customElement: true,
+        },
+      ],
+      exports: [
+        {
+          kind: 'js',
+          name: 'XFoo',
+          declaration: {
+            name: 'XFoo',
+            module: 'src/components/x-foo.js',
+          },
+        },
+      ],
+    },
   ],
 };
 
@@ -118,6 +154,21 @@ test('cross-package references are unsupported', () => {
     '1.0.0'
   );
   assert.equal(result, undefined);
+});
+
+test(`resolves a custom element defintion to it's declaration`, () => {
+  const definitionModule = pkg.modules.find((m) => m.path === 'x-foo.js')!;
+  const elementExport = definitionModule.exports![0];
+  const declarationReference = elementExport!.declaration;
+  const result = resolveReference(
+    pkg,
+    definitionModule,
+    declarationReference,
+    'test-package',
+    '1.0.0'
+  );
+  console.log('result', result);
+  assert.ok(result);
 });
 
 test.run();

--- a/packages/custom-elements-manifest-tools/test/test-data/lion-button-0.18.1.json
+++ b/packages/custom-elements-manifest-tools/test/test-data/lion-button-0.18.1.json
@@ -1,0 +1,1325 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "define.d.ts",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "define.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "index.d.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LionButton",
+          "declaration": {
+            "name": "LionButton",
+            "module": "\"./src/LionButton.js\""
+          }
+        },
+        {
+          "kind": "js",
+          "name": "LionButtonReset",
+          "declaration": {
+            "name": "LionButtonReset",
+            "module": "\"./src/LionButtonReset.js\""
+          }
+        },
+        {
+          "kind": "js",
+          "name": "LionButtonSubmit",
+          "declaration": {
+            "name": "LionButtonSubmit",
+            "module": "\"./src/LionButtonSubmit.js\""
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "index.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LionButton",
+          "declaration": {
+            "name": "LionButton",
+            "module": "./src/LionButton.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "LionButtonReset",
+          "declaration": {
+            "name": "LionButtonReset",
+            "module": "./src/LionButtonReset.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "LionButtonSubmit",
+          "declaration": {
+            "name": "LionButtonSubmit",
+            "module": "./src/LionButtonSubmit.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "lion-button-reset.d.ts",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "lion-button-reset.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "lion-button-reset",
+          "declaration": {
+            "name": "LionButtonReset",
+            "module": "/src/LionButtonReset.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "lion-button-submit.d.ts",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "lion-button-submit.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "lion-button-submit",
+          "declaration": {
+            "name": "LionButtonSubmit",
+            "module": "/src/LionButtonSubmit.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "lion-button.d.ts",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "lion-button.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "lion-button",
+          "declaration": {
+            "name": "LionButton",
+            "module": "/src/LionButton.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/LionButton.d.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Use LionButton (or LionButtonReset|LionButtonSubmit) when there is a need to extend HTMLButtonElement.\nIt allows to create complex shadow DOM for buttons needing this. Think of:\n- a material Design button that needs a JS controlled ripple\n- a LionSelectRich invoker that needs a complex shadow DOM structure\n(for styling/maintainability purposes)\n- a specialized button (for instance a primary button or icon button in a Design System) that\nneeds a simple api: `<my-button>text</my-button>` is always better than\n`<button class=\"my-button\"><div class=\"my-button__container\">text</div><button>`\n\nIn other cases, whenever you can, still use native HTMLButtonElement (`<button>`).\n\nNote that LionButton is meant for buttons with type=\"button\". It's cleaner and more\nlightweight than LionButtonReset and LionButtonSubmit, which should only be considered when native\n`<form>` support is needed:\n- When type=\"reset|submit\" should be supported, use LionButtonReset.\n- When implicit form submission should be supported on top, use LionButtonSubmit.",
+          "name": "LionButton",
+          "members": [
+            {
+              "kind": "field",
+              "name": "type",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "active",
+              "type": {
+                "text": "boolean"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_buttonId",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "__setupEvents",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "__mousedownHandler",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "__keydownHandler",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "field",
+              "name": "__keyupHandler",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ]
+            }
+          ],
+          "superclass": {
+            "name": "LionButton_base",
+            "module": "src/LionButton.d.ts"
+          },
+          "tagName": "lion-button",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LionButton",
+          "declaration": {
+            "name": "LionButton",
+            "module": "src/LionButton.d.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/LionButton.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Use LionButton (or LionButtonReset|LionButtonSubmit) when there is a need to extend HTMLButtonElement.\nIt allows to create complex shadow DOM for buttons needing this. Think of:\n- a material Design button that needs a JS controlled ripple\n- a LionSelectRich invoker that needs a complex shadow DOM structure\n(for styling/maintainability purposes)\n- a specialized button (for instance a primary button or icon button in a Design System) that\nneeds a simple api: `<my-button>text</my-button>` is always better than\n`<button class=\"my-button\"><div class=\"my-button__container\">text</div><button>`\n\nIn other cases, whenever you can, still use native HTMLButtonElement (`<button>`).\n\nNote that LionButton is meant for buttons with type=\"button\". It's cleaner and more\nlightweight than LionButtonReset and LionButtonSubmit, which should only be considered when native\n`<form>` support is needed:\n- When type=\"reset|submit\" should be supported, use LionButtonReset.\n- When implicit form submission should be supported on top, use LionButtonSubmit.",
+          "name": "LionButton",
+          "members": [
+            {
+              "kind": "method",
+              "name": "__setupEvents",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "__mousedownHandler",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "__keydownHandler",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ],
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "__keyupHandler",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ],
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "type",
+              "type": {
+                "text": "string"
+              },
+              "default": "'button'",
+              "privacy": "public",
+              "attribute": "type",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "active",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "privacy": "public",
+              "attribute": "active",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "_buttonId",
+              "default": "`button-${Math.random().toString(36).substr(2, 10)}`"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "active",
+              "fieldName": "active"
+            },
+            {
+              "name": "type",
+              "fieldName": "type"
+            }
+          ],
+          "mixins": [
+            {
+              "name": "DisabledWithTabIndexMixin",
+              "package": "@lion/core"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "@lion/core"
+          },
+          "tagName": "lion-button",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LionButton",
+          "declaration": {
+            "name": "LionButton",
+            "module": "src/LionButton.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/LionButtonReset.d.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "This adds functionality for form buttons (type 'submit' and 'reset').\nIt allows to submit or reset a <form> by spawning a click on a temporrary native button inside\nthe form.\nUse LionButtonSubmit when implicit form submission should be supported as well.\n\nFunctionality in this button is not purely for type=\"reset\", also for type=\"submit\".\nFor mainainability purposes the submit functionality is part of LionButtonReset\n(it needs the same logic).\nLionButtonReset could therefore actually be considered as 'LionButtonForm' (without the\nimplicit form submission logic), but LionButtonReset is an easier to grasp name for\nApplication Developers: for reset buttons, always use LionButtonReset, for submit\nbuttons always use LionButtonSubmit.",
+          "name": "LionButtonReset",
+          "members": [
+            {
+              "kind": "field",
+              "name": "__submitAndResetHelperButton",
+              "type": {
+                "text": "HTMLButtonElement"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "__preventEventLeakage",
+              "privacy": "private",
+              "description": "Prevents that someone who listens outside or on form catches the click event",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_setupSubmitAndResetHelperOnConnected",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_form",
+              "type": {
+                "text": "HTMLFormElement|null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "_teardownSubmitAndResetHelperOnDisconnected",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__clickDelegationHandler",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "Promise<void>"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "ev",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ],
+              "description": "Delegate click, by flashing a native button as a direct child\nof the form, and firing click on this button. This will fire the form submit\nwithout side effects caused by the click bubbling back up to lion-button."
+            },
+            {
+              "kind": "field",
+              "name": "__setupDelegationInConstructor",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "__setupEvents",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__mousedownHandler",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__keydownHandler",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ],
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__keyupHandler",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ],
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "type",
+              "type": {
+                "text": "string"
+              },
+              "default": "'button'",
+              "privacy": "public",
+              "attribute": "type",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "active",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "privacy": "public",
+              "attribute": "active",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_buttonId",
+              "default": "`button-${Math.random().toString(36).substr(2, 10)}`",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "LionButton",
+            "module": "/src/LionButton.js"
+          },
+          "tagName": "lion-button-reset",
+          "customElement": true,
+          "attributes": [
+            {
+              "name": "active",
+              "fieldName": "active",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "name": "type",
+              "fieldName": "type",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LionButtonReset",
+          "declaration": {
+            "name": "LionButtonReset",
+            "module": "src/LionButtonReset.d.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/LionButtonReset.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "This adds functionality for form buttons (type 'submit' and 'reset').\nIt allows to submit or reset a <form> by spawning a click on a temporrary native button inside\nthe form.\nUse LionButtonSubmit when implicit form submission should be supported as well.\n\nFunctionality in this button is not purely for type=\"reset\", also for type=\"submit\".\nFor mainainability purposes the submit functionality is part of LionButtonReset\n(it needs the same logic).\nLionButtonReset could therefore actually be considered as 'LionButtonForm' (without the\nimplicit form submission logic), but LionButtonReset is an easier to grasp name for\nApplication Developers: for reset buttons, always use LionButtonReset, for submit\nbuttons always use LionButtonSubmit.",
+          "name": "LionButtonReset",
+          "members": [
+            {
+              "kind": "method",
+              "name": "__preventEventLeakage",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ],
+              "description": "Prevents that someone who listens outside or on form catches the click event",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "_setupSubmitAndResetHelperOnConnected",
+              "privacy": "protected"
+            },
+            {
+              "kind": "method",
+              "name": "_teardownSubmitAndResetHelperOnDisconnected",
+              "privacy": "protected"
+            },
+            {
+              "kind": "method",
+              "name": "__clickDelegationHandler",
+              "parameters": [
+                {
+                  "name": "ev",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ],
+              "description": "Delegate click, by flashing a native button as a direct child\nof the form, and firing click on this button. This will fire the form submit\nwithout side effects caused by the click bubbling back up to lion-button.",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "Promise<void>"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__setupDelegationInConstructor",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "type",
+              "type": {
+                "text": "string"
+              },
+              "default": "'reset'",
+              "privacy": "public",
+              "attribute": "type",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "__submitAndResetHelperButton",
+              "type": {
+                "text": "HTMLButtonElement"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__setupEvents",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__mousedownHandler",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__keydownHandler",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ],
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__keyupHandler",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ],
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "active",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "privacy": "public",
+              "attribute": "active",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_buttonId",
+              "default": "`button-${Math.random().toString(36).substr(2, 10)}`",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "LionButton",
+            "module": "/src/LionButton.js"
+          },
+          "tagName": "lion-button-reset",
+          "customElement": true,
+          "attributes": [
+            {
+              "name": "active",
+              "fieldName": "active",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "name": "type",
+              "fieldName": "type",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LionButtonReset",
+          "declaration": {
+            "name": "LionButtonReset",
+            "module": "src/LionButtonReset.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/LionButtonSubmit.d.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Contains all the funcionaility of LionButton and LionButtonReset. On top of that it\nsupports implicit form submission.\n\nUse when:\n- the Application Developer should be able to switch types between 'submit'|'reset'|'button'\n(this is similar to how native HTMLButtonElement works)\n- a submit button with native form support is needed",
+          "name": "LionButtonSubmit",
+          "members": [
+            {
+              "kind": "field",
+              "name": "_nativeButtonNode",
+              "type": {
+                "text": "HTMLButtonElement|null"
+              },
+              "privacy": "protected"
+            },
+            {
+              "kind": "field",
+              "name": "__implicitSubmitHelperButton",
+              "type": {
+                "text": "HTMLButtonElement|null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__preventEventLeakage",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ],
+              "description": "Prevents that someone who listens outside or on form catches the click event",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButtonReset",
+                "module": "src/LionButtonReset.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "_setupSubmitAndResetHelperOnConnected",
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "LionButtonReset",
+                "module": "src/LionButtonReset.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "_teardownSubmitAndResetHelperOnDisconnected",
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "LionButtonReset",
+                "module": "src/LionButtonReset.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__clickDelegationHandler",
+              "parameters": [
+                {
+                  "name": "ev",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ],
+              "description": "Delegate click, by flashing a native button as a direct child\nof the form, and firing click on this button. This will fire the form submit\nwithout side effects caused by the click bubbling back up to lion-button.",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "Promise<void>"
+                }
+              },
+              "inheritedFrom": {
+                "name": "LionButtonReset",
+                "module": "src/LionButtonReset.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__setupDelegationInConstructor",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButtonReset",
+                "module": "src/LionButtonReset.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "type",
+              "type": {
+                "text": "string"
+              },
+              "default": "'reset'",
+              "privacy": "public",
+              "attribute": "type",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "__submitAndResetHelperButton",
+              "type": {
+                "text": "HTMLButtonElement"
+              },
+              "inheritedFrom": {
+                "name": "LionButtonReset",
+                "module": "src/LionButtonReset.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__setupEvents",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__mousedownHandler",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__keydownHandler",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ],
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__keyupHandler",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ],
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "active",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "privacy": "public",
+              "attribute": "active",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_buttonId",
+              "default": "`button-${Math.random().toString(36).substr(2, 10)}`",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "LionButtonReset",
+            "module": "/src/LionButtonReset.js"
+          },
+          "tagName": "lion-button-submit",
+          "customElement": true,
+          "attributes": [
+            {
+              "name": "active",
+              "fieldName": "active",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "name": "type",
+              "fieldName": "type",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LionButtonSubmit",
+          "declaration": {
+            "name": "LionButtonSubmit",
+            "module": "src/LionButtonSubmit.d.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/LionButtonSubmit.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Contains all the funcionaility of LionButton and LionButtonReset. On top of that it\nsupports implicit form submission.\n\nUse when:\n- the Application Developer should be able to switch types between 'submit'|'reset'|'button'\n(this is similar to how native HTMLButtonElement works)\n- a submit button with native form support is needed",
+          "name": "LionButtonSubmit",
+          "members": [
+            {
+              "kind": "field",
+              "name": "_nativeButtonNode",
+              "type": {
+                "text": "HTMLButtonElement|null"
+              },
+              "privacy": "protected"
+            },
+            {
+              "kind": "method",
+              "name": "_setupSubmitAndResetHelperOnConnected",
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "LionButtonReset",
+                "module": "src/LionButtonReset.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "_teardownSubmitAndResetHelperOnDisconnected",
+              "privacy": "protected",
+              "inheritedFrom": {
+                "name": "LionButtonReset",
+                "module": "src/LionButtonReset.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "type",
+              "type": {
+                "text": "string"
+              },
+              "default": "'submit'",
+              "privacy": "public",
+              "attribute": "type",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "__implicitSubmitHelperButton",
+              "type": {
+                "text": "HTMLButtonElement|null"
+              },
+              "default": "null"
+            },
+            {
+              "kind": "method",
+              "name": "__preventEventLeakage",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ],
+              "description": "Prevents that someone who listens outside or on form catches the click event",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButtonReset",
+                "module": "src/LionButtonReset.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__clickDelegationHandler",
+              "parameters": [
+                {
+                  "name": "ev",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ],
+              "description": "Delegate click, by flashing a native button as a direct child\nof the form, and firing click on this button. This will fire the form submit\nwithout side effects caused by the click bubbling back up to lion-button.",
+              "privacy": "protected",
+              "return": {
+                "type": {
+                  "text": "Promise<void>"
+                }
+              },
+              "inheritedFrom": {
+                "name": "LionButtonReset",
+                "module": "src/LionButtonReset.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__setupDelegationInConstructor",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButtonReset",
+                "module": "src/LionButtonReset.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "__submitAndResetHelperButton",
+              "type": {
+                "text": "HTMLButtonElement"
+              },
+              "inheritedFrom": {
+                "name": "LionButtonReset",
+                "module": "src/LionButtonReset.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__setupEvents",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__mousedownHandler",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__keydownHandler",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ],
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "__keyupHandler",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ],
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "active",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "privacy": "public",
+              "attribute": "active",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_buttonId",
+              "default": "`button-${Math.random().toString(36).substr(2, 10)}`",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "LionButtonReset",
+            "module": "/src/LionButtonReset.js"
+          },
+          "tagName": "lion-button-submit",
+          "customElement": true,
+          "attributes": [
+            {
+              "name": "active",
+              "fieldName": "active",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            },
+            {
+              "name": "type",
+              "fieldName": "type",
+              "inheritedFrom": {
+                "name": "LionButton",
+                "module": "src/LionButton.js"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LionButtonSubmit",
+          "declaration": {
+            "name": "LionButtonSubmit",
+            "module": "src/LionButtonSubmit.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "test/demos.screenshots-test.d.ts",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "test/demos.screenshots-test.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "test/lion-button.test.d.ts",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "test-suites/LionButton.suite.d.ts",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "LionButtonSuite",
+          "return": {
+            "type": {
+              "text": "void"
+            }
+          },
+          "parameters": [
+            {
+              "name": "{ klass }",
+              "optional": true,
+              "type": {
+                "text": "{\n    klass?: typeof LionButton | undefined;\n}"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LionButtonSuite",
+          "declaration": {
+            "name": "LionButtonSuite",
+            "module": "test-suites/LionButton.suite.d.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "test-suites/LionButtonReset.suite.d.ts",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "LionButtonResetSuite",
+          "return": {
+            "type": {
+              "text": "void"
+            }
+          },
+          "parameters": [
+            {
+              "name": "{ klass }",
+              "optional": true,
+              "type": {
+                "text": "{\n    klass?: typeof LionButtonReset | undefined;\n}"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LionButtonResetSuite",
+          "declaration": {
+            "name": "LionButtonResetSuite",
+            "module": "test-suites/LionButtonReset.suite.d.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "test-suites/LionButtonSubmit.suite.d.ts",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "LionButtonSubmitSuite",
+          "return": {
+            "type": {
+              "text": "void"
+            }
+          },
+          "parameters": [
+            {
+              "name": "{ klass }",
+              "optional": true,
+              "type": {
+                "text": "{\n    klass?: typeof LionButtonSubmit | undefined;\n}"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LionButtonSubmitSuite",
+          "declaration": {
+            "name": "LionButtonSubmitSuite",
+            "module": "test-suites/LionButtonSubmit.suite.d.ts"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/site-server/src/catalog/routes/element/element-template.ts
+++ b/packages/site-server/src/catalog/routes/element/element-template.ts
@@ -51,7 +51,11 @@ export const renderElement = ({
   console.log('elementDeclaration', declaration);
 
   if (declaration === undefined || declaration.kind !== 'class') {
-    return `<h1>Error</h1>`;
+    console.log('tried to resolve', module.path, declarationRef);
+    return `
+      <h1>Error</h1>
+      <h2>Element declaration not found</h2>
+    `;
   }
 
   return `

--- a/packages/site-server/src/catalog/routes/element/element-template.ts
+++ b/packages/site-server/src/catalog/routes/element/element-template.ts
@@ -51,7 +51,6 @@ export const renderElement = ({
   console.log('elementDeclaration', declaration);
 
   if (declaration === undefined || declaration.kind !== 'class') {
-    console.log('tried to resolve', module.path, declarationRef);
     return `
       <h1>Error</h1>
       <h2>Element declaration not found</h2>


### PR DESCRIPTION
The FirestoreRepository was calculating the reference string for the element _declaration_ incorrectly when the definition/export (the define() call) was in a different module from the declaration (the class). It was assuming that the modules were the same, so the element page couldn't then find the declaration in the manifest when it was showing element details.

This adds a few tests that were passing before the fix as I investigated the issue, and one catalog test that fails without the fix.

Fixes #1371 