### PR TITLE
Add catalog page component

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "test": "wireit",
     "build:dev": "wireit",
     "build:prod": "wireit",
-    "serve:dev": "wireit",
-    "serve:prod": "wireit",
     "serve:docker": "docker-compose -f docker/docker-compose.yml up --build --remove-orphans",
     "watch:dev": "npm run build:dev && (npm run serve:dev > /dev/null 2>&1 & WIREIT_FAILURES=continue npm run build-and-check:dev --watch)",
     "watch:prod": "npm run build:prod && (npm run serve:prod & WIREIT_FAILURES=continue npm run build-and-check:prod --watch)",
@@ -47,23 +45,6 @@
       "dependencies": [
         "./packages/custom-elements-manifest-tools:test",
         "./packages/catalog-server:test"
-      ]
-    },
-    "serve:prod": {
-      "command": "node packages/site-server/lib/prod-server.js",
-      "files": [],
-      "output": [],
-      "dependencies": [
-        "./packages/site-server:build",
-        "./packages/site-content:build:prod"
-      ]
-    },
-    "serve:dev": {
-      "command": "node --enable-source-maps packages/site-server/lib/dev-server.js",
-      "files": [],
-      "output": [],
-      "dependencies": [
-        "build:dev"
       ]
     },
     "build:prod": {

--- a/packages/site-client/package.json
+++ b/packages/site-client/package.json
@@ -33,7 +33,7 @@
       "clean": "if-file-deleted"
     },
     "build:prod": {
-      "command": "esbuild --color --outdir=bundled --bundle --splitting --minify src/entrypoints/*.ts",
+      "command": "esbuild --color --outdir=bundled --format=esm --bundle --splitting --minify src/entrypoints/*.ts",
       "files": [
         "src/**/*.ts"
       ],

--- a/packages/site-client/src/components/wco-catalog-page.ts
+++ b/packages/site-client/src/components/wco-catalog-page.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {html, css, LitElement} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import './wco-top-bar.js';
+import './wco-catalog-search.js';
+
+@customElement('wco-catalog-page')
+export class WCOCatalogPage extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+  `;
+
+  render() {
+    return html`
+      <wco-top-bar></wco-top-bar>
+      <h1>Catalog</h1>
+      <wco-catalog-search></wco-catalog-search>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'wco-catalog-page': WCOCatalogPage;
+  }
+}

--- a/packages/site-client/src/entrypoints/catalog.ts
+++ b/packages/site-client/src/entrypoints/catalog.ts
@@ -4,5 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import '../components/wco-catalog-search.js';
-import '../components/wco-top-bar.js';
+import '../components/wco-catalog-page.js';

--- a/packages/site-server/package.json
+++ b/packages/site-server/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "wireit",
     "check": "wireit",
-    "serve:dev": "wireit"
+    "serve:dev": "wireit",
+    "serve:prod": "wireit"
   },
   "wireit": {
     "build": {
@@ -36,6 +37,12 @@
     },
     "serve:dev": {
       "command": "node --enable-source-maps ./lib/dev-server.js",
+      "dependencies": [
+        "build"
+      ]
+    },
+    "serve:prod": {
+      "command": "node --enable-source-maps ./lib/prod-server.js",
       "dependencies": [
         "build"
       ]

--- a/packages/site-server/package.json
+++ b/packages/site-server/package.json
@@ -16,7 +16,8 @@
     "build": {
       "command": "find src -name \"*.ts\" | xargs esbuild --format=esm --target=es2022 --color --outdir=lib",
       "dependencies": [
-        "../custom-elements-manifest-tools:build"
+        "../custom-elements-manifest-tools:build",
+        "../site-client:build"
       ],
       "files": [
         "src/**/*.ts"

--- a/packages/site-server/src/catalog/routes/catalog/catalog-route.ts
+++ b/packages/site-server/src/catalog/routes/catalog/catalog-route.ts
@@ -26,11 +26,7 @@ export const handleCatalogRoute = async (
     renderPage({
       title: `Web Components Catalog`,
       scripts: ['/js/hydrate.js', '/js/catalog.js'],
-      content: render(html`
-        <wco-top-bar></wco-top-bar>
-        <h1>Catalog</h1>
-        <wco-catalog-search></wco-catalog-search>
-      `),
+      content: render(html`<wco-catalog-page></wco-catalog-page>`),
     })
   );
   context.type = 'html';


### PR DESCRIPTION
This puts all of the catalog page into a component, making it easy to associate styles with the page.

It also fixes the build error in site-client and adds a script to run the prod site-server. I used that to check that reactive properties still work when using the `--format=esm` flag on esbuild.