### PR TITLE
Partition custom element documents with a namespace

### DIFF
--- a/packages/catalog-server/src/lib/firestore/firestore-repository.ts
+++ b/packages/catalog-server/src/lib/firestore/firestore-repository.ts
@@ -333,6 +333,7 @@ export class FirestoreRepository implements Repository {
       ];
 
       batch.create(customElementsRef.doc(), {
+        namespace: this.namespace,
         package: packageName,
         version,
         distTags,
@@ -506,6 +507,7 @@ export class FirestoreRepository implements Repository {
       .collectionGroup('customElements')
       .withConverter(customElementConverter)
       .where('isLatest', '==', true)
+      .where('namespace', '==', this.namespace)
       .limit(limit ?? 25);
 
     if (query !== undefined) {

--- a/packages/catalog-server/src/test/lib/firestore/firestore-repository_test.ts
+++ b/packages/catalog-server/src/test/lib/firestore/firestore-repository_test.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  getModule,
+  Version,
+} from '@webcomponents/custom-elements-manifest-tools';
+import {
+  CustomElementDeclaration,
+  CustomElementExport,
+  Package,
+} from 'custom-elements-manifest';
+import {suite} from 'uvu';
+import * as assert from 'uvu/assert';
+
+import {FirestoreRepository} from '../../../lib/firestore/firestore-repository.js';
+
+const test = suite('FirestoreRepository tests');
+
+test('Limits element searches to a namespace', async () => {
+  const manifest: Package = {
+    schemaVersion: '1.0.0',
+    readme: 'README.md',
+    modules: [
+      {
+        kind: 'javascript-module',
+        path: 'foo.js',
+        exports: [
+          {
+            kind: 'custom-element-definition',
+            name: 'x-foo',
+            declaration: {
+              name: 'FooElement',
+            },
+          },
+        ],
+        declarations: [
+          {
+            kind: 'class',
+            customElement: true,
+            tagName: 'x-foo',
+            name: 'FooElement',
+            members: [],
+          },
+        ],
+      },
+    ],
+  };
+
+  const module = getModule(manifest, 'foo.js')!;
+  const customElementExport = module.exports![0] as CustomElementExport;
+  const customElementDeclaration =
+    module.declarations![0] as CustomElementDeclaration;
+
+  const repo1 = new FirestoreRepository('firestore-repository-test-1');
+  const repo2 = new FirestoreRepository('firestore-repository-test-2');
+
+  const writeElement = async (repo: FirestoreRepository) =>
+    repo.writeCustomElements(
+      {name: 'foo', version: '1.0.0', description: 'test package'} as Version,
+      [
+        {
+          package: manifest,
+          module,
+          export: customElementExport,
+          declaration: customElementDeclaration,
+          declarationReference: customElementExport.declaration,
+        },
+      ],
+      ['latest'],
+      'joe'
+    );
+
+  await Promise.all([writeElement(repo1), writeElement(repo2)]);
+  const [result1, result2] = await Promise.all([
+    repo1.queryElements({query: 'foo'}),
+    repo2.queryElements({query: 'foo'}),
+  ]);
+  assert.equal(result1.length, 1);
+  assert.equal(result2.length, 1);
+});
+
+test.run();


### PR DESCRIPTION
Last part of https://github.com/webcomponents/webcomponents.org/issues/1351

This is done with a field on CustomElement and a hard-coded query clause so that we can use a single index for the customElements collection.