### PR TITLE
Deploy to cloud run on push to main

### DIFF
--- a/cloud-build/deploy-main.yaml
+++ b/cloud-build/deploy-main.yaml
@@ -1,5 +1,4 @@
-# Cloud Build config for main branch auto deployment
-# of the webcomponents.org catalog server.
+# Cloud Build config for main branch auto deployment of webcomponents.org.
 
 timeout: 10m
 
@@ -11,8 +10,8 @@ options:
 substitutions:
   _REGION: us-west2
   _TAG: main-${SHORT_SHA}
-  _IMAGE_URL_CATALOG: us.gcr.io/${PROJECT_ID}/catalog:${SHORT_SHA}
-  _IMAGE_URL_SITE: us.gcr.io/${PROJECT_ID}/site:${SHORT_SHA}
+  _IMAGE_URL_CATALOG: us.gcr.io/${PROJECT_ID}/main/catalog:${SHORT_SHA}
+  _IMAGE_URL_SITE: us.gcr.io/${PROJECT_ID}/main/site:${SHORT_SHA}
   _IMAGE_CACHE_TTL: 168h # 1 week
   _CATALOG_GRAPHQL_URL: https://${_TAG}---catalog-khswqo4xea-wl.a.run.app
 

--- a/cloud-build/deploy-main.yaml
+++ b/cloud-build/deploy-main.yaml
@@ -1,0 +1,124 @@
+# Cloud Build config for main branch auto deployment
+# of the webcomponents.org catalog server.
+
+timeout: 10m
+
+options:
+  # https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#machinetype
+  machineType: N1_HIGHCPU_8
+  dynamic_substitutions: true
+
+substitutions:
+  _REGION: us-west2
+  _TAG: main-${SHORT_SHA}
+  _IMAGE_URL_CATALOG: us.gcr.io/${PROJECT_ID}/catalog:${SHORT_SHA}
+  _IMAGE_URL_SITE: us.gcr.io/${PROJECT_ID}/site:${SHORT_SHA}
+  _IMAGE_CACHE_TTL: 168h # 1 week
+  _CATALOG_GRAPHQL_URL: https://${_TAG}---catalog-khswqo4xea-wl.a.run.app
+
+steps:
+  # Build catalog Docker image.
+  - id: build-catalog
+    waitFor: ['-'] # Start immediately
+    name: gcr.io/kaniko-project/executor:latest
+    args:
+      - --dockerfile=./docker/catalog/Dockerfile
+      - --destination=${_IMAGE_URL_CATALOG}
+      - --cache=true
+      - --cache-ttl=${_IMAGE_CACHE_TTL}
+
+  # Build site Docker image.
+  - id: build-site
+    waitFor: ['-'] # Start immediately
+    name: gcr.io/kaniko-project/executor:latest
+    args:
+      - --dockerfile=./docker/site/Dockerfile
+      - --destination=${_IMAGE_URL_SITE}
+      - --cache=true
+      - --cache-ttl=${_IMAGE_CACHE_TTL}
+
+  # Create catalog Cloud Run revision.
+  - id: deploy-catalog
+    waitFor:
+      - build-catalog
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - beta
+      - run
+      - deploy
+      - catalog
+      - --region=${_REGION}
+      - --platform=managed
+      - --image=${_IMAGE_URL_CATALOG}
+      - --quiet
+      - --no-traffic
+      - --tag=${_TAG}
+      - --memory=1Gi
+      - --cpu=1
+      - --concurrency=200
+      - --min-instances=1
+      - --max-instances=1000
+      - --update-env-vars=GCP_PROJECT_ID=${PROJECT_ID}
+
+  # Create site Cloud Run revision.
+  - id: deploy-site
+    waitFor:
+      - build-site
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - beta
+      - run
+      - deploy
+      - site
+      - --region=${_REGION}
+      - --platform=managed
+      - --image=${_IMAGE_URL_SITE}
+      - --quiet
+      - --no-traffic
+      - --tag=${_TAG}
+      - --memory=1Gi
+      - --cpu=1
+      - --concurrency=200
+      - --min-instances=1
+      - --max-instances=1000
+      - --update-env-vars=CATALOG_GRAPHQL_URL=${_CATALOG_GRAPHQL_URL}
+
+  # Route traffic to new catalog revision.
+  - id: route-catalog
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    waitFor:
+      # Wait for both deploys so that both revisions go live at similar times
+      - deploy-catalog
+      - deploy-site
+    args:
+      - beta
+      - run
+      - services
+      - update-traffic
+      - catalog
+      - --region=${_REGION}
+      - --platform=managed
+      - --quiet
+      - --to-tags=${_TAG}=100
+
+  # Route traffic to new site revision.
+  - id: route-site
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    waitFor:
+      # Wait for both deploys so that both revisions go live at similar times
+      - deploy-catalog
+      - deploy-site
+    args:
+      - beta
+      - run
+      - services
+      - update-traffic
+      - site
+      - --region=${_REGION}
+      - --platform=managed
+      - --quiet
+      - --to-tags=${_TAG}=100

--- a/package-lock.json
+++ b/package-lock.json
@@ -2255,13 +2255,13 @@
       "dev": true
     },
     "node_modules/@graphql-codegen/typed-document-node": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.7.tgz",
-      "integrity": "sha512-9raCw2n2gGfdK4gFZaY/fbrUH/ADpZOhlNZ/l6iEzdEEGJbAIAIsovnt9LBnpJ+VCmUBfmjhpn1QQBEwyceVlw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.8.tgz",
+      "integrity": "sha512-yY30XJ0Jf5DJyii6k1+uKKJonHn8Tqy7ZUk65w3p2zrL22exlwqHb3rpsKnHKv9iLQT7309tMYAa4F65VSJHfw==",
       "dev": true,
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
-        "@graphql-codegen/visitor-plugin-common": "2.13.2",
+        "@graphql-codegen/visitor-plugin-common": "2.13.3",
         "auto-bind": "~4.0.0",
         "change-case-all": "1.0.14",
         "tslib": "~2.4.0"
@@ -2277,14 +2277,14 @@
       "dev": true
     },
     "node_modules/@graphql-codegen/typescript": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.2.tgz",
-      "integrity": "sha512-FWyEcJTHSxkImNgDRfsg4yBMJ11qPA6sPJ7v8Kviv5MaOFybclVSZ8WWfp7D8Dc6ix4zWfMd4dIl9ZIL/AJu8A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-ch8Lzjp8XnN8P70uYBmsjv7FWJQ47qletlShPHk7n4RRsnLkah3J9iSEUIALqM25Wl6EjEmHlxoAgSBILz+sjg==",
       "dev": true,
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
         "@graphql-codegen/schema-ast": "^2.5.1",
-        "@graphql-codegen/visitor-plugin-common": "2.13.2",
+        "@graphql-codegen/visitor-plugin-common": "2.13.3",
         "auto-bind": "~4.0.0",
         "tslib": "~2.4.0"
       },
@@ -2293,14 +2293,14 @@
       }
     },
     "node_modules/@graphql-codegen/typescript-resolvers": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-2.7.7.tgz",
-      "integrity": "sha512-0SaFbZlTxOkeyuJHpZH3pXtQUKoimeqsOv1WEN6tyPfSieeJ8cCNyTPS8IrnylRQ38FBJHHt3lmN4LBIiUKZWg==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-2.7.8.tgz",
+      "integrity": "sha512-O/eAX7AfFxy9tcZ9tZrxlJ8EkKF8S10RlMQU8HasVsP13znk/SZOmO8vCoci2Bxj7tL9ZCSfZVZpc+a6REn30Q==",
       "dev": true,
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
-        "@graphql-codegen/typescript": "^2.8.2",
-        "@graphql-codegen/visitor-plugin-common": "2.13.2",
+        "@graphql-codegen/typescript": "^2.8.3",
+        "@graphql-codegen/visitor-plugin-common": "2.13.3",
         "@graphql-tools/utils": "^8.8.0",
         "auto-bind": "~4.0.0",
         "tslib": "~2.4.0"
@@ -2322,9 +2322,9 @@
       "dev": true
     },
     "node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.2.tgz",
-      "integrity": "sha512-qCZ4nfI1YjDuPz4lqGi0s4/5lOqHxdiQPFSwrXDENjHW+Z0oAiNYj6CFqob9ai2tLtXXKSUzMh/eeZDPmTrfhQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.3.tgz",
+      "integrity": "sha512-5gFDQGuCE5tIBo9KtDPZ8kL6cf1VJwDGj6nO9ERa0HJNk5osT50NhSf6H61LEnM3Gclbo96Ib1GCp3KdLwHoGg==",
       "dev": true,
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
@@ -24026,7 +24026,6 @@
         "@js-temporal/polyfill": "^0.4.2",
         "@koa/cors": "^4.0.0",
         "@koa/router": "^12.0.0",
-        "@lit-labs/ssr": "^2.2.3",
         "@webcomponents/catalog-api": "0.0.0",
         "@webcomponents/custom-elements-manifest-tools": "0.0.0",
         "@webcomponents/internal-site-client": "0.0.0",
@@ -24094,6 +24093,7 @@
         "@apollo/client": "^3.7.0",
         "@koa/cors": "^4.0.0",
         "@koa/router": "^12.0.0",
+        "@lit-labs/ssr": "^2.2.3",
         "@types/koa": "^2.13.5",
         "@types/koa__cors": "^3.3.0",
         "@types/koa__router": "^12.0.0",
@@ -25879,13 +25879,13 @@
       }
     },
     "@graphql-codegen/typed-document-node": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.7.tgz",
-      "integrity": "sha512-9raCw2n2gGfdK4gFZaY/fbrUH/ADpZOhlNZ/l6iEzdEEGJbAIAIsovnt9LBnpJ+VCmUBfmjhpn1QQBEwyceVlw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.8.tgz",
+      "integrity": "sha512-yY30XJ0Jf5DJyii6k1+uKKJonHn8Tqy7ZUk65w3p2zrL22exlwqHb3rpsKnHKv9iLQT7309tMYAa4F65VSJHfw==",
       "dev": true,
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
-        "@graphql-codegen/visitor-plugin-common": "2.13.2",
+        "@graphql-codegen/visitor-plugin-common": "2.13.3",
         "auto-bind": "~4.0.0",
         "change-case-all": "1.0.14",
         "tslib": "~2.4.0"
@@ -25900,14 +25900,14 @@
       }
     },
     "@graphql-codegen/typescript": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.2.tgz",
-      "integrity": "sha512-FWyEcJTHSxkImNgDRfsg4yBMJ11qPA6sPJ7v8Kviv5MaOFybclVSZ8WWfp7D8Dc6ix4zWfMd4dIl9ZIL/AJu8A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-ch8Lzjp8XnN8P70uYBmsjv7FWJQ47qletlShPHk7n4RRsnLkah3J9iSEUIALqM25Wl6EjEmHlxoAgSBILz+sjg==",
       "dev": true,
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
         "@graphql-codegen/schema-ast": "^2.5.1",
-        "@graphql-codegen/visitor-plugin-common": "2.13.2",
+        "@graphql-codegen/visitor-plugin-common": "2.13.3",
         "auto-bind": "~4.0.0",
         "tslib": "~2.4.0"
       },
@@ -25921,14 +25921,14 @@
       }
     },
     "@graphql-codegen/typescript-resolvers": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-2.7.7.tgz",
-      "integrity": "sha512-0SaFbZlTxOkeyuJHpZH3pXtQUKoimeqsOv1WEN6tyPfSieeJ8cCNyTPS8IrnylRQ38FBJHHt3lmN4LBIiUKZWg==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-2.7.8.tgz",
+      "integrity": "sha512-O/eAX7AfFxy9tcZ9tZrxlJ8EkKF8S10RlMQU8HasVsP13znk/SZOmO8vCoci2Bxj7tL9ZCSfZVZpc+a6REn30Q==",
       "dev": true,
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
-        "@graphql-codegen/typescript": "^2.8.2",
-        "@graphql-codegen/visitor-plugin-common": "2.13.2",
+        "@graphql-codegen/typescript": "^2.8.3",
+        "@graphql-codegen/visitor-plugin-common": "2.13.3",
         "@graphql-tools/utils": "^8.8.0",
         "auto-bind": "~4.0.0",
         "tslib": "~2.4.0"
@@ -25943,9 +25943,9 @@
       }
     },
     "@graphql-codegen/visitor-plugin-common": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.2.tgz",
-      "integrity": "sha512-qCZ4nfI1YjDuPz4lqGi0s4/5lOqHxdiQPFSwrXDENjHW+Z0oAiNYj6CFqob9ai2tLtXXKSUzMh/eeZDPmTrfhQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.3.tgz",
+      "integrity": "sha512-5gFDQGuCE5tIBo9KtDPZ8kL6cf1VJwDGj6nO9ERa0HJNk5osT50NhSf6H61LEnM3Gclbo96Ib1GCp3KdLwHoGg==",
       "dev": true,
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
@@ -27941,7 +27941,6 @@
         "@js-temporal/polyfill": "^0.4.2",
         "@koa/cors": "^4.0.0",
         "@koa/router": "^12.0.0",
-        "@lit-labs/ssr": "^2.2.3",
         "@types/koa__cors": "^3.3.0",
         "@types/koa__router": "^12.0.0",
         "@types/koa-bodyparser": "^4.3.8",
@@ -27997,6 +27996,7 @@
         "@apollo/client": "^3.7.0",
         "@koa/cors": "^4.0.0",
         "@koa/router": "^12.0.0",
+        "@lit-labs/ssr": "^2.2.3",
         "@types/koa": "^2.13.5",
         "@types/koa__cors": "^3.3.0",
         "@types/koa__router": "^12.0.0",

--- a/packages/catalog-server/package.json
+++ b/packages/catalog-server/package.json
@@ -95,7 +95,6 @@
     "@js-temporal/polyfill": "^0.4.2",
     "@koa/cors": "^4.0.0",
     "@koa/router": "^12.0.0",
-    "@lit-labs/ssr": "^2.2.3",
     "@webcomponents/catalog-api": "0.0.0",
     "@webcomponents/custom-elements-manifest-tools": "0.0.0",
     "@webcomponents/internal-site-client": "0.0.0",

--- a/packages/catalog-server/src/lib/firestore/firestore-repository.ts
+++ b/packages/catalog-server/src/lib/firestore/firestore-repository.ts
@@ -43,7 +43,7 @@ import {packageVersionConverter} from './package-version-converter.js';
 import {customElementConverter} from './custom-element-converter.js';
 import {validationProblemConverter} from './validation-problem-converter.js';
 
-const projectId = 'wc-catalog';
+const projectId = process.env['GCP_PROJECT_ID'] || 'wc-catalog';
 firebase.initializeApp({projectId});
 export const db = new Firestore({projectId});
 

--- a/packages/site-server/package.json
+++ b/packages/site-server/package.json
@@ -81,6 +81,7 @@
     "@apollo/client": "^3.7.0",
     "@koa/cors": "^4.0.0",
     "@koa/router": "^12.0.0",
+    "@lit-labs/ssr": "^2.2.3",
     "@types/koa": "^2.13.5",
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^12.0.0",


### PR DESCRIPTION
This configuration automatically deploys the catalog and site servers to Google Cloud Run whenever a commit is pushed to main.

To test this right now you'll need to have privileges on our GCP project, and then you can run the following command to establish authenticated proxies, and then visit http://localhost:5453 and http://localhost:6453

```
(gcloud beta run services proxy --project=webcomponents-org-test --region=us-west2 --port=5453 site \
& gcloud beta run services proxy --project=webcomponents-org-test --region=us-west2 --port=6453 catalog)
```

Also:
- Fixes another dependency that was in the wrong `package.json`
- Adds the `GCP_PROJECT_ID` environment variable to the catalog server since it was hard-coded before

Open issues (non-blocking for this PR):
- We get `Error: 7 PERMISSION_DENIED: Missing or insufficient permissions.` errors when trying to use the "bootstrap-packages" endpoint (despite setting up liberal privileges in the firebase console)
- The URL is still hard-coded to the wrong value on the client side, so search can't work. We'll need to update https://github.com/webcomponents/webcomponents.org/blob/c192d08f73e3f3a6c647ff178d5a44d27fa5e9a9/packages/site-client/src/components/wco-catalog-search.ts#L16
- We'll want a separate, slightly different configuration for generating PR previews

Part of https://github.com/webcomponents/webcomponents.org/issues/1340
Part of https://github.com/webcomponents/webcomponents.org/issues/1339