### PR TITLE
Deploy previews to cloud run when PR opened

### DIFF
--- a/.github/workflows/pr-preview-url-comment.yml
+++ b/.github/workflows/pr-preview-url-comment.yml
@@ -1,0 +1,35 @@
+# GitHub Action that creates a comment displaying the preview URL for each PR.
+name: PR Preview URL Comment
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  preview-url-comment:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # https://github.com/peter-evans/create-or-update-comment
+      - name: Post comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            A live preview of this PR will be available at the URL below and will update on each commit. =
+            The build takes ~5-10 minutes, and will 404 until finished.
+
+            https://pr${{ github.event.number }}---site-khswqo4xea-wl.a.run.app/
+
+            > **Warning**
+            > Until our Cloud Run project is public, only authorized users can view the above URL.
+            > The easiest way to view it authenticated is to run the following proxy command and visit http://localhost:5453
+            >
+            > ```
+            > (gcloud beta run services proxy --project=webcomponents-org-test --region=us-west2 --tag=pr${{ github.event.number }} --port=5453 site \
+            > & gcloud beta run services proxy --project=webcomponents-org-test --region=us-west2 --tag=pr${{ github.event.number }} --port=6453 catalog)
+            > ```
+          reactions: eyes

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ We use the following port scheme for consistency and to prevent collisions:
 - [`localhost:5450`](http://localhost:5450): site-server in dev mode
 - [`localhost:5451`](http://localhost:5451): site-server in prod mode
 - [`localhost:5452`](http://localhost:5452): site-server in docker
+- [`localhost:5452`](http://localhost:5453): site-server gcloud proxy
 - [`localhost:6451`](http://localhost:6451): catalog-server
 - [`localhost:6452`](http://localhost:6452): catalog-server in docker
+- [`localhost:6452`](http://localhost:6453): catalog-server gcloud proxy
 - [`localhost:7450`](http://localhost:7450): firestore-emulator

--- a/cloud-build/deploy-main.yaml
+++ b/cloud-build/deploy-main.yaml
@@ -1,5 +1,4 @@
-# Cloud Build config for main branch auto deployment
-# of the webcomponents.org catalog server.
+# Cloud Build config for main branch auto deployment of webcomponents.org.
 
 timeout: 10m
 
@@ -11,8 +10,8 @@ options:
 substitutions:
   _REGION: us-west2
   _TAG: main-${SHORT_SHA}
-  _IMAGE_URL_CATALOG: us.gcr.io/${PROJECT_ID}/catalog:${SHORT_SHA}
-  _IMAGE_URL_SITE: us.gcr.io/${PROJECT_ID}/site:${SHORT_SHA}
+  _IMAGE_URL_CATALOG: us.gcr.io/${PROJECT_ID}/main/catalog:${SHORT_SHA}
+  _IMAGE_URL_SITE: us.gcr.io/${PROJECT_ID}/main/site:${SHORT_SHA}
   _IMAGE_CACHE_TTL: 168h # 1 week
   _CATALOG_GRAPHQL_URL: https://${_TAG}---catalog-khswqo4xea-wl.a.run.app
 

--- a/cloud-build/deploy-main.yaml
+++ b/cloud-build/deploy-main.yaml
@@ -1,0 +1,124 @@
+# Cloud Build config for main branch auto deployment
+# of the webcomponents.org catalog server.
+
+timeout: 10m
+
+options:
+  # https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#machinetype
+  machineType: N1_HIGHCPU_8
+  dynamic_substitutions: true
+
+substitutions:
+  _REGION: us-west2
+  _TAG: main-${SHORT_SHA}
+  _IMAGE_URL_CATALOG: us.gcr.io/${PROJECT_ID}/catalog:${SHORT_SHA}
+  _IMAGE_URL_SITE: us.gcr.io/${PROJECT_ID}/site:${SHORT_SHA}
+  _IMAGE_CACHE_TTL: 168h # 1 week
+  _CATALOG_GRAPHQL_URL: https://${_TAG}---catalog-khswqo4xea-wl.a.run.app
+
+steps:
+  # Build catalog Docker image.
+  - id: build-catalog
+    waitFor: ['-'] # Start immediately
+    name: gcr.io/kaniko-project/executor:latest
+    args:
+      - --dockerfile=./docker/catalog/Dockerfile
+      - --destination=${_IMAGE_URL_CATALOG}
+      - --cache=true
+      - --cache-ttl=${_IMAGE_CACHE_TTL}
+
+  # Build site Docker image.
+  - id: build-site
+    waitFor: ['-'] # Start immediately
+    name: gcr.io/kaniko-project/executor:latest
+    args:
+      - --dockerfile=./docker/site/Dockerfile
+      - --destination=${_IMAGE_URL_SITE}
+      - --cache=true
+      - --cache-ttl=${_IMAGE_CACHE_TTL}
+
+  # Create catalog Cloud Run revision.
+  - id: deploy-catalog
+    waitFor:
+      - build-catalog
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - beta
+      - run
+      - deploy
+      - catalog
+      - --region=${_REGION}
+      - --platform=managed
+      - --image=${_IMAGE_URL_CATALOG}
+      - --quiet
+      - --no-traffic
+      - --tag=${_TAG}
+      - --memory=1Gi
+      - --cpu=1
+      - --concurrency=200
+      - --min-instances=1
+      - --max-instances=1000
+      - --update-env-vars=GCP_PROJECT_ID=${PROJECT_ID}
+
+  # Create site Cloud Run revision.
+  - id: deploy-site
+    waitFor:
+      - build-site
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - beta
+      - run
+      - deploy
+      - site
+      - --region=${_REGION}
+      - --platform=managed
+      - --image=${_IMAGE_URL_SITE}
+      - --quiet
+      - --no-traffic
+      - --tag=${_TAG}
+      - --memory=1Gi
+      - --cpu=1
+      - --concurrency=200
+      - --min-instances=1
+      - --max-instances=1000
+      - --update-env-vars=CATALOG_GRAPHQL_URL=${_CATALOG_GRAPHQL_URL}
+
+  # Route traffic to new catalog revision.
+  - id: route-catalog
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    waitFor:
+      # Wait for both deploys so that both revisions go live at similar times
+      - deploy-catalog
+      - deploy-site
+    args:
+      - beta
+      - run
+      - services
+      - update-traffic
+      - catalog
+      - --region=${_REGION}
+      - --platform=managed
+      - --quiet
+      - --to-tags=${_TAG}=100
+
+  # Route traffic to new site revision.
+  - id: route-site
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    waitFor:
+      # Wait for both deploys so that both revisions go live at similar times
+      - deploy-catalog
+      - deploy-site
+    args:
+      - beta
+      - run
+      - services
+      - update-traffic
+      - site
+      - --region=${_REGION}
+      - --platform=managed
+      - --quiet
+      - --to-tags=${_TAG}=100

--- a/cloud-build/deploy-pr.yaml
+++ b/cloud-build/deploy-pr.yaml
@@ -1,0 +1,85 @@
+# Cloud Build config for PR branch auto deployment of webcomponents.org.
+
+timeout: 10m
+
+options:
+  # https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#machinetype
+  machineType: N1_HIGHCPU_8
+  dynamic_substitutions: true
+
+substitutions:
+  _REGION: us-west2
+  _TAG: pr${_PR_NUMBER}
+  _IMAGE_URL_CATALOG: us.gcr.io/${PROJECT_ID}/pr/catalog:${SHORT_SHA}
+  _IMAGE_URL_SITE: us.gcr.io/${PROJECT_ID}/pr/site:${SHORT_SHA}
+  _IMAGE_CACHE_TTL: 168h # 1 week
+  _CATALOG_GRAPHQL_URL: https://${_TAG}---catalog-khswqo4xea-wl.a.run.app
+
+steps:
+  # Build catalog Docker image.
+  - id: build-catalog
+    waitFor: ['-'] # Start immediately
+    name: gcr.io/kaniko-project/executor:latest
+    args:
+      - --dockerfile=./docker/catalog/Dockerfile
+      - --destination=${_IMAGE_URL_CATALOG}
+      - --cache=true
+      - --cache-ttl=${_IMAGE_CACHE_TTL}
+
+  # Build site Docker image.
+  - id: build-site
+    waitFor: ['-'] # Start immediately
+    name: gcr.io/kaniko-project/executor:latest
+    args:
+      - --dockerfile=./docker/site/Dockerfile
+      - --destination=${_IMAGE_URL_SITE}
+      - --cache=true
+      - --cache-ttl=${_IMAGE_CACHE_TTL}
+
+  # Create catalog Cloud Run revision.
+  - id: deploy-catalog
+    waitFor:
+      - build-catalog
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - beta
+      - run
+      - deploy
+      - catalog
+      - --region=${_REGION}
+      - --platform=managed
+      - --image=${_IMAGE_URL_CATALOG}
+      - --quiet
+      - --no-traffic
+      - --tag=${_TAG}
+      - --memory=1Gi
+      - --cpu=1
+      - --concurrency=default # Unlimited
+      - --min-instances=0
+      - --max-instances=1
+      - --update-env-vars=GCP_PROJECT_ID=${PROJECT_ID}
+
+  # Create site Cloud Run revision.
+  - id: deploy-site
+    waitFor:
+      - build-site
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - beta
+      - run
+      - deploy
+      - site
+      - --region=${_REGION}
+      - --platform=managed
+      - --image=${_IMAGE_URL_SITE}
+      - --quiet
+      - --no-traffic
+      - --tag=${_TAG}
+      - --memory=1Gi
+      - --cpu=1
+      - --concurrency=default # Unlimited
+      - --min-instances=0
+      - --max-instances=1
+      - --update-env-vars=CATALOG_GRAPHQL_URL=${_CATALOG_GRAPHQL_URL}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2255,13 +2255,13 @@
       "dev": true
     },
     "node_modules/@graphql-codegen/typed-document-node": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.7.tgz",
-      "integrity": "sha512-9raCw2n2gGfdK4gFZaY/fbrUH/ADpZOhlNZ/l6iEzdEEGJbAIAIsovnt9LBnpJ+VCmUBfmjhpn1QQBEwyceVlw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.8.tgz",
+      "integrity": "sha512-yY30XJ0Jf5DJyii6k1+uKKJonHn8Tqy7ZUk65w3p2zrL22exlwqHb3rpsKnHKv9iLQT7309tMYAa4F65VSJHfw==",
       "dev": true,
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
-        "@graphql-codegen/visitor-plugin-common": "2.13.2",
+        "@graphql-codegen/visitor-plugin-common": "2.13.3",
         "auto-bind": "~4.0.0",
         "change-case-all": "1.0.14",
         "tslib": "~2.4.0"
@@ -2277,14 +2277,14 @@
       "dev": true
     },
     "node_modules/@graphql-codegen/typescript": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.2.tgz",
-      "integrity": "sha512-FWyEcJTHSxkImNgDRfsg4yBMJ11qPA6sPJ7v8Kviv5MaOFybclVSZ8WWfp7D8Dc6ix4zWfMd4dIl9ZIL/AJu8A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-ch8Lzjp8XnN8P70uYBmsjv7FWJQ47qletlShPHk7n4RRsnLkah3J9iSEUIALqM25Wl6EjEmHlxoAgSBILz+sjg==",
       "dev": true,
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
         "@graphql-codegen/schema-ast": "^2.5.1",
-        "@graphql-codegen/visitor-plugin-common": "2.13.2",
+        "@graphql-codegen/visitor-plugin-common": "2.13.3",
         "auto-bind": "~4.0.0",
         "tslib": "~2.4.0"
       },
@@ -2293,14 +2293,14 @@
       }
     },
     "node_modules/@graphql-codegen/typescript-resolvers": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-2.7.7.tgz",
-      "integrity": "sha512-0SaFbZlTxOkeyuJHpZH3pXtQUKoimeqsOv1WEN6tyPfSieeJ8cCNyTPS8IrnylRQ38FBJHHt3lmN4LBIiUKZWg==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-2.7.8.tgz",
+      "integrity": "sha512-O/eAX7AfFxy9tcZ9tZrxlJ8EkKF8S10RlMQU8HasVsP13znk/SZOmO8vCoci2Bxj7tL9ZCSfZVZpc+a6REn30Q==",
       "dev": true,
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
-        "@graphql-codegen/typescript": "^2.8.2",
-        "@graphql-codegen/visitor-plugin-common": "2.13.2",
+        "@graphql-codegen/typescript": "^2.8.3",
+        "@graphql-codegen/visitor-plugin-common": "2.13.3",
         "@graphql-tools/utils": "^8.8.0",
         "auto-bind": "~4.0.0",
         "tslib": "~2.4.0"
@@ -2322,9 +2322,9 @@
       "dev": true
     },
     "node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.2.tgz",
-      "integrity": "sha512-qCZ4nfI1YjDuPz4lqGi0s4/5lOqHxdiQPFSwrXDENjHW+Z0oAiNYj6CFqob9ai2tLtXXKSUzMh/eeZDPmTrfhQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.3.tgz",
+      "integrity": "sha512-5gFDQGuCE5tIBo9KtDPZ8kL6cf1VJwDGj6nO9ERa0HJNk5osT50NhSf6H61LEnM3Gclbo96Ib1GCp3KdLwHoGg==",
       "dev": true,
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
@@ -24026,7 +24026,6 @@
         "@js-temporal/polyfill": "^0.4.2",
         "@koa/cors": "^4.0.0",
         "@koa/router": "^12.0.0",
-        "@lit-labs/ssr": "^2.2.3",
         "@webcomponents/catalog-api": "0.0.0",
         "@webcomponents/custom-elements-manifest-tools": "0.0.0",
         "@webcomponents/internal-site-client": "0.0.0",
@@ -24094,6 +24093,7 @@
         "@apollo/client": "^3.7.0",
         "@koa/cors": "^4.0.0",
         "@koa/router": "^12.0.0",
+        "@lit-labs/ssr": "^2.2.3",
         "@types/koa": "^2.13.5",
         "@types/koa__cors": "^3.3.0",
         "@types/koa__router": "^12.0.0",
@@ -25879,13 +25879,13 @@
       }
     },
     "@graphql-codegen/typed-document-node": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.7.tgz",
-      "integrity": "sha512-9raCw2n2gGfdK4gFZaY/fbrUH/ADpZOhlNZ/l6iEzdEEGJbAIAIsovnt9LBnpJ+VCmUBfmjhpn1QQBEwyceVlw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.8.tgz",
+      "integrity": "sha512-yY30XJ0Jf5DJyii6k1+uKKJonHn8Tqy7ZUk65w3p2zrL22exlwqHb3rpsKnHKv9iLQT7309tMYAa4F65VSJHfw==",
       "dev": true,
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
-        "@graphql-codegen/visitor-plugin-common": "2.13.2",
+        "@graphql-codegen/visitor-plugin-common": "2.13.3",
         "auto-bind": "~4.0.0",
         "change-case-all": "1.0.14",
         "tslib": "~2.4.0"
@@ -25900,14 +25900,14 @@
       }
     },
     "@graphql-codegen/typescript": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.2.tgz",
-      "integrity": "sha512-FWyEcJTHSxkImNgDRfsg4yBMJ11qPA6sPJ7v8Kviv5MaOFybclVSZ8WWfp7D8Dc6ix4zWfMd4dIl9ZIL/AJu8A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-ch8Lzjp8XnN8P70uYBmsjv7FWJQ47qletlShPHk7n4RRsnLkah3J9iSEUIALqM25Wl6EjEmHlxoAgSBILz+sjg==",
       "dev": true,
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
         "@graphql-codegen/schema-ast": "^2.5.1",
-        "@graphql-codegen/visitor-plugin-common": "2.13.2",
+        "@graphql-codegen/visitor-plugin-common": "2.13.3",
         "auto-bind": "~4.0.0",
         "tslib": "~2.4.0"
       },
@@ -25921,14 +25921,14 @@
       }
     },
     "@graphql-codegen/typescript-resolvers": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-2.7.7.tgz",
-      "integrity": "sha512-0SaFbZlTxOkeyuJHpZH3pXtQUKoimeqsOv1WEN6tyPfSieeJ8cCNyTPS8IrnylRQ38FBJHHt3lmN4LBIiUKZWg==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-2.7.8.tgz",
+      "integrity": "sha512-O/eAX7AfFxy9tcZ9tZrxlJ8EkKF8S10RlMQU8HasVsP13znk/SZOmO8vCoci2Bxj7tL9ZCSfZVZpc+a6REn30Q==",
       "dev": true,
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
-        "@graphql-codegen/typescript": "^2.8.2",
-        "@graphql-codegen/visitor-plugin-common": "2.13.2",
+        "@graphql-codegen/typescript": "^2.8.3",
+        "@graphql-codegen/visitor-plugin-common": "2.13.3",
         "@graphql-tools/utils": "^8.8.0",
         "auto-bind": "~4.0.0",
         "tslib": "~2.4.0"
@@ -25943,9 +25943,9 @@
       }
     },
     "@graphql-codegen/visitor-plugin-common": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.2.tgz",
-      "integrity": "sha512-qCZ4nfI1YjDuPz4lqGi0s4/5lOqHxdiQPFSwrXDENjHW+Z0oAiNYj6CFqob9ai2tLtXXKSUzMh/eeZDPmTrfhQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.3.tgz",
+      "integrity": "sha512-5gFDQGuCE5tIBo9KtDPZ8kL6cf1VJwDGj6nO9ERa0HJNk5osT50NhSf6H61LEnM3Gclbo96Ib1GCp3KdLwHoGg==",
       "dev": true,
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.7.2",
@@ -27941,7 +27941,6 @@
         "@js-temporal/polyfill": "^0.4.2",
         "@koa/cors": "^4.0.0",
         "@koa/router": "^12.0.0",
-        "@lit-labs/ssr": "^2.2.3",
         "@types/koa__cors": "^3.3.0",
         "@types/koa__router": "^12.0.0",
         "@types/koa-bodyparser": "^4.3.8",
@@ -27997,6 +27996,7 @@
         "@apollo/client": "^3.7.0",
         "@koa/cors": "^4.0.0",
         "@koa/router": "^12.0.0",
+        "@lit-labs/ssr": "^2.2.3",
         "@types/koa": "^2.13.5",
         "@types/koa__cors": "^3.3.0",
         "@types/koa__router": "^12.0.0",

--- a/packages/catalog-server/package.json
+++ b/packages/catalog-server/package.json
@@ -95,7 +95,6 @@
     "@js-temporal/polyfill": "^0.4.2",
     "@koa/cors": "^4.0.0",
     "@koa/router": "^12.0.0",
-    "@lit-labs/ssr": "^2.2.3",
     "@webcomponents/catalog-api": "0.0.0",
     "@webcomponents/custom-elements-manifest-tools": "0.0.0",
     "@webcomponents/internal-site-client": "0.0.0",

--- a/packages/catalog-server/src/lib/firestore/firestore-repository.ts
+++ b/packages/catalog-server/src/lib/firestore/firestore-repository.ts
@@ -43,7 +43,7 @@ import {packageVersionConverter} from './package-version-converter.js';
 import {customElementConverter} from './custom-element-converter.js';
 import {validationProblemConverter} from './validation-problem-converter.js';
 
-const projectId = 'wc-catalog';
+const projectId = process.env['GCP_PROJECT_ID'] || 'wc-catalog';
 firebase.initializeApp({projectId});
 export const db = new Firestore({projectId});
 

--- a/packages/site-server/package.json
+++ b/packages/site-server/package.json
@@ -81,6 +81,7 @@
     "@apollo/client": "^3.7.0",
     "@koa/cors": "^4.0.0",
     "@koa/router": "^12.0.0",
+    "@lit-labs/ssr": "^2.2.3",
     "@types/koa": "^2.13.5",
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^12.0.0",


### PR DESCRIPTION
Follow up to https://github.com/webcomponents/webcomponents.org/pull/1394

Pretty much the same as the `deploy-main.yaml` config, but doesn't update routing, and only allows up to 1 instance.

This is very similar to what we do on lit.dev, except this time I'm not including the SHA, so instead of getting a new preview URL for every commit, the same URL is updated on each commit instead.

Includes a GitHub Action which posts a comment to the PR with the URL.

Part of https://github.com/webcomponents/webcomponents.org/issues/1340
Part of https://github.com/webcomponents/webcomponents.org/issues/1339