### PR TITLE
Add active class to nav links based on current URL

### DIFF
--- a/packages/site-client/src/components/wco-top-bar.ts
+++ b/packages/site-client/src/components/wco-top-bar.ts
@@ -6,6 +6,9 @@
 
 import {html, css, LitElement} from 'lit';
 import {customElement} from 'lit/decorators.js';
+import {classMap} from 'lit/directives/class-map.js';
+
+const pathStartsWith = (s: string) => window.location.pathname.startsWith(s);
 
 @customElement('wco-top-bar')
 export class WCOTopBar extends LitElement {
@@ -68,16 +71,44 @@ export class WCOTopBar extends LitElement {
     nav > a:hover {
       background: #00000008;
     }
+
+    nav > a.active {
+      color: blue;
+    }
   `;
 
   render() {
     return html`
       <span id="title"><span id="logo">WC</span> WebComponents.org</span>
       <nav>
-        <a href="/catalog">Catalog</a>
-        <a href="/docs">Docs</a>
-        <a href="/articles">Articles</a>
-        <a href="/community">Community</a>
+        <a
+          class="${classMap({
+            active: pathStartsWith('/catalog'),
+          })}"
+          href="/catalog"
+          >Catalog</a
+        >
+        <a
+          class="${classMap({
+            active: pathStartsWith('/docs'),
+          })}"
+          href="/docs"
+          >Docs</a
+        >
+        <a
+          class="${classMap({
+            active: pathStartsWith('/articles'),
+          })}"
+          href="/articles"
+          >Articles</a
+        >
+        <a
+          class="${classMap({
+            active: pathStartsWith('/community'),
+          })}"
+          href="/community"
+          >Community</a
+        >
       </nav>
     `;
   }

--- a/packages/site-server/src/catalog/routes/catalog/catalog-route.ts
+++ b/packages/site-server/src/catalog/routes/catalog/catalog-route.ts
@@ -22,6 +22,9 @@ export const handleCatalogRoute = async (
     unknown
   >
 ) => {
+  // URL isn't exactly a Location, but it's close enough for read-only uses
+  window.location = new URL(context.URL.href) as unknown as Location;
+
   context.body = Readable.from(
     renderPage({
       title: `Web Components Catalog`,

--- a/packages/site-server/src/catalog/routes/element/element-route.ts
+++ b/packages/site-server/src/catalog/routes/element/element-route.ts
@@ -89,6 +89,9 @@ export const handleElementRoute = async (
     manifest: customElementsManifest,
   };
 
+  // URL isn't exactly a Location, but it's close enough for read-only uses
+  window.location = new URL(context.URL.href) as unknown as Location;
+
   context.type = 'html';
   context.status = 200;
   context.body = Readable.from(


### PR DESCRIPTION
This gives the active top-nav link a blue color (temporary) for both client-side and server-side rendered pages.