### PR TITLE
Add command to export emulator data, import on start

### DIFF
--- a/packages/catalog-server/.gitignore
+++ b/packages/catalog-server/.gitignore
@@ -5,6 +5,9 @@
 /tsconfig.tsbuildinfo
 *-debug.log
 
+/firebase-data/*
+!/firebase-data/.gitkeep
+
 index.js
 index.js.map
 index.d.ts

--- a/packages/catalog-server/package.json
+++ b/packages/catalog-server/package.json
@@ -19,6 +19,7 @@
     "test": "wireit",
     "test:manual": "wireit",
     "emulators:start": "wireit",
+    "emulators:export": "wireit",
     "firebase": "firebase"
   },
   "wireit": {
@@ -64,13 +65,21 @@
       "output": []
     },
     "emulators:start": {
-      "command": "firebase emulators:start --project wc-catalog",
+      "command": "firebase emulators:start --project wc-catalog --import firebase-data",
       "service": true,
       "files": [
         "firebase.json",
         "firestore.indexes.json",
         "firestore.rules"
-      ]
+      ],
+      "env": {
+        "IMPORT": {
+          "external": true
+        }
+      }
+    },
+    "emulators:export": {
+      "command": "firebase emulators:export --project wc-catalog -f firebase-data"
     },
     "test:manual": {
       "command": "NODE_OPTIONS='--enable-source-maps' FIRESTORE_EMULATOR_HOST=localhost:7450 uvu test \"_test\\.js$\"",


### PR DESCRIPTION
This adds `emulators:export` to the catalog-server scripts. It can be run when the emulator is running to export data to catalog-server/firebase-data/. The `--import` flag on emulators:start works as long as that data folder exists, even if it's empty.