### PR TITLE
[site-content] Add custom nav HTML generator

### DIFF
--- a/packages/site-content/site/_includes/layouts/docs.11ty.cjs
+++ b/packages/site-content/site/_includes/layouts/docs.11ty.cjs
@@ -21,9 +21,6 @@ module.exports = {
 
     const navigationEntries = this.eleventyNavigation(data.collections.all);
 
-    // TODO: use custom navigation HTML generation so that we can leave out
-    // links for section items.
-    // See https://github.com/lit/lit.dev/blob/main/packages/lit-dev-content/site/_includes/docs-nav.html
     const navigationHTML = navToHTML(
       navigationEntries,
       {slot: 'outline'},

--- a/packages/site-content/site/_includes/layouts/docs.11ty.cjs
+++ b/packages/site-content/site/_includes/layouts/docs.11ty.cjs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+const {navToHTML} = require('./nav.cjs');
+
 module.exports = {
   async render(data) {
     const {renderPage, html, unsafeHTML} = await import(
@@ -22,14 +24,17 @@ module.exports = {
     // TODO: use custom navigation HTML generation so that we can leave out
     // links for section items.
     // See https://github.com/lit/lit.dev/blob/main/packages/lit-dev-content/site/_includes/docs-nav.html
-    const navigationHTML = this.eleventyNavigationToHtml(navigationEntries);
+    const navigationHTML = navToHTML(
+      navigationEntries,
+      {slot: 'outline'},
+      data.page
+    );
 
     return [
       ...renderPage({
         ...data,
         content: html`<wco-nav-page>
-          <div slot="outline">${unsafeHTML(navigationHTML)}</div>
-          ${unsafeHTML(data.content)}
+          ${unsafeHTML(navigationHTML)} ${unsafeHTML(data.content)}
         </wco-nav-page>`,
       }),
     ].join('');

--- a/packages/site-content/site/_includes/layouts/nav.cjs
+++ b/packages/site-content/site/_includes/layouts/nav.cjs
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Converts an eleventy-navigation entries array to a nested <ul> list.
+ *
+ * Entries with `url: false` (caused by `permalink: false` in page data) do
+ * not generate a link, and so are just section headers.
+ *
+ * When an entry matches the current page, it's `<li>` element is give the
+ * `active` class.
+ */
+const navToHTML = (navigationEntries, attributes, page) => {
+  const makeItems = (entries) =>
+    entries
+      ?.map(
+        (e) =>
+          `<li ${getEntryClassString(e, page)}>${maybeWrapInLink(
+            e,
+            e.key
+          )}${renderChildren(e.children, page)}</li>`
+      )
+      .join('') ?? '';
+
+  return `<ul ${getAttributesString(attributes)}>${makeItems(
+    navigationEntries
+  )}</ul>`;
+};
+
+const getEntryClassString = (entry, page) =>
+  entry.url === page.url ? 'class="active"' : '';
+
+const maybeWrapInLink = (entry, s) =>
+  entry.url !== false ? `<a href="${entry.url}">${s}</a>` : s;
+
+const renderChildren = (children, page) =>
+  children?.length > 0 ? navToHTML(children, {}, page) : '';
+
+const getAttributesString = (attributes) =>
+  attributes !== undefined
+    ? Object.entries(attributes)
+        .map(([name, value]) => `${name}="${value}"`)
+        .join(' ')
+    : '';
+
+module.exports = {
+  navToHTML,
+};


### PR DESCRIPTION
Adds a utility that generates a `<ul>` from an eleventy-navigation entries list.

This differs from the [built-in HTML generator](https://www.11ty.dev/docs/plugins/navigation/#render-the-menu-items-using-the-eleventynavigationtohtml-or-eleventynavigationtomarkdown-filters) by not adding links to entries that don't have a URL - which we use for section headings.