### PR TITLE
Add search endpoint to site-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4655,17 +4655,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@urql/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
-      "dependencies": {
-        "wonka": "^6.1.2"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@web/config-loader": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.1.3.tgz",
@@ -23526,11 +23515,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/wonka": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.2.tgz",
-      "integrity": "sha512-zNrXPMccg/7OEp9tSfFkMgTvhhowqasiSHdJ3eCZolXxVTV/aT6HUTofoZk9gwRbGoFey/Nss3JaZKUMKMbofg=="
-    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -23817,9 +23801,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@urql/core": "^3.0.4",
         "@webcomponents/catalog-api": "^0.0.0",
-        "graphql": "^16.6.0",
         "lit": "^2.6.0",
         "lit-analyzer": "^1.2.1"
       }
@@ -27529,14 +27511,6 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
-    "@urql/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-Mnxtq4I4QeFJsgs7Iytw+HyhiGxISR6qtyk66c9tipozLZ6QVxrCiUPF2HY4BxNIabaxcp+rivadvm8NAnXj4Q==",
-      "requires": {
-        "wonka": "^6.1.2"
-      }
-    },
     "@web/config-loader": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.1.3.tgz",
@@ -27666,9 +27640,7 @@
     "@webcomponents/internal-site-client": {
       "version": "file:packages/site-client",
       "requires": {
-        "@urql/core": "^3.0.4",
         "@webcomponents/catalog-api": "^0.0.0",
-        "graphql": "^16.6.0",
         "lit": "^2.6.0",
         "lit-analyzer": "^1.2.1"
       }
@@ -27698,7 +27670,7 @@
         "@types/marked": "^4.0.8",
         "@web/dev-server": "^0.1.34",
         "@webcomponents/internal-site-content": "^0.0.0",
-        "google-auth-library": "*",
+        "google-auth-library": "^8.7.0",
         "koa": "^2.13.4",
         "koa-conditional-get": "^3.0.0",
         "koa-etag": "^4.0.0",
@@ -42388,11 +42360,6 @@
         "assert-never": "^1.2.1",
         "babel-walk": "3.0.0-canary-5"
       }
-    },
-    "wonka": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.1.2.tgz",
-      "integrity": "sha512-zNrXPMccg/7OEp9tSfFkMgTvhhowqasiSHdJ3eCZolXxVTV/aT6HUTofoZk9gwRbGoFey/Nss3JaZKUMKMbofg=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/packages/catalog-server/package.json
+++ b/packages/catalog-server/package.json
@@ -49,7 +49,11 @@
     },
     "start:dev": {
       "command": "FIRESTORE_EMULATOR_HOST=localhost:7450 npm start",
-      "service": true,
+      "service": {
+        "readyWhen": {
+          "lineMatches": "Server started"
+        }
+      },
       "dependencies": [
         "build",
         "emulators:start"
@@ -66,7 +70,11 @@
     },
     "emulators:start": {
       "command": "firebase emulators:start --project wc-catalog --import firebase-data",
-      "service": true,
+      "service": {
+        "readyWhen": {
+          "lineMatches": "All emulators ready"
+        }
+      },
       "files": [
         "firebase.json",
         "firestore.indexes.json",

--- a/packages/site-client/package.json
+++ b/packages/site-client/package.json
@@ -86,9 +86,7 @@
     }
   },
   "dependencies": {
-    "@urql/core": "^3.0.4",
     "@webcomponents/catalog-api": "^0.0.0",
-    "graphql": "^16.6.0",
     "lit": "^2.6.0",
     "lit-analyzer": "^1.2.1"
   }

--- a/packages/site-client/src/components/wco-catalog-search.ts
+++ b/packages/site-client/src/components/wco-catalog-search.ts
@@ -6,27 +6,9 @@
 
 import {html, css, LitElement} from 'lit';
 import {customElement, query, state} from 'lit/decorators.js';
-import {gql, createClient, defaultExchanges} from '@urql/core';
 import type {CustomElement} from '@webcomponents/catalog-api/lib/schema.js';
 
 import './wco-element-card.js';
-
-const client = createClient({
-  // TODO (justinfagnani): get this URL from server
-  url: 'http://localhost:6451/graphql',
-  exchanges: defaultExchanges,
-});
-
-const elementsQuery = gql`
-  query Elements($query: String) {
-    elements(query: $query, limit: 16) {
-      tagName
-      package
-      version
-      className
-    }
-  }
-`;
 
 @customElement('wco-catalog-search')
 export class WCOCatalogSearch extends LitElement {
@@ -78,10 +60,9 @@ export class WCOCatalogSearch extends LitElement {
 
   async _onChange() {
     const searchText = this._search.value;
-    const result = await client
-      .query(elementsQuery, {query: searchText})
-      .toPromise();
-    this._elements = result.data?.elements;
+    const response = await fetch(`/catalog/search?query=${searchText}`);
+    const result = await response.json();
+    this._elements = result.elements;
   }
 }
 

--- a/packages/site-server/package.json
+++ b/packages/site-server/package.json
@@ -98,7 +98,8 @@
     "test": {
       "command": "NODE_OPTIONS=--enable-source-maps uvu test \"_test\\.js$\"",
       "dependencies": [
-        "start:dev"
+        "start:dev",
+        "../catalog-server:start:dev"
       ]
     }
   },

--- a/packages/site-server/src/lib/catalog/router.ts
+++ b/packages/site-server/src/lib/catalog/router.ts
@@ -6,10 +6,16 @@
 
 import Router from '@koa/router';
 import {handleCatalogRoute} from './routes/catalog/catalog-route.js';
+import {handleCatalogSearchRoute} from './routes/catalog/search-route.js';
 import {handleElementRoute} from './routes/element/element-route.js';
+// import cors from '@koa/cors';
 
 export const catalogRouter = new Router();
 
+// catalogRouter.use(cors());
+
 catalogRouter.get('/', handleCatalogRoute);
+
+catalogRouter.get('/search', handleCatalogSearchRoute);
 
 catalogRouter.get('/element/:path+', handleElementRoute);

--- a/packages/site-server/src/lib/catalog/routes/catalog/search-route.ts
+++ b/packages/site-server/src/lib/catalog/routes/catalog/search-route.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {DefaultContext, DefaultState, ParameterizedContext} from 'koa';
+import Router from '@koa/router';
+import {client} from '../../graphql.js';
+import {gql} from '@apollo/client/core/index.js';
+
+import '@webcomponents/internal-site-client/lib/entrypoints/catalog.js';
+
+const elementsQuery = gql`
+  query Elements($query: String) {
+    elements(query: $query, limit: 16) {
+      tagName
+      package
+      version
+      className
+    }
+  }
+`;
+
+export const handleCatalogSearchRoute = async (
+  context: ParameterizedContext<
+    DefaultState,
+    DefaultContext & Router.RouterParamContext<DefaultState, DefaultContext>,
+    unknown
+  >
+) => {
+  const searchText = context.query['query'];
+  context.type = 'json';
+
+  if (typeof searchText !== 'string') {
+    context.status = 400;
+    context.body = {
+      message: 'Query parmeter `query` must be a string',
+    };
+    return;
+  }
+
+  const result = await client.query({
+    query: elementsQuery,
+    variables: {query: searchText},
+  });
+
+  if (result.error) {
+    context.status = 500;
+    context.body = {
+      message: result.error,
+    };
+    return;
+  }
+
+  context.status = 200;
+  context.body = {
+    elements: result.data?.elements,
+  };
+};

--- a/packages/site-server/src/test/catalog/routes_test.ts
+++ b/packages/site-server/src/test/catalog/routes_test.ts
@@ -14,19 +14,19 @@ const request = async (path: string) => fetch(`http://127.0.0.1:5450${path}`);
 
 test('Returns 404 for malformed element page URL', async () => {
   // Missing package and element:
-  assert.equal((await request('/element/')).status, 404);
+  assert.equal((await request('/catalog/element/')).status, 404);
 
   // Missing element name on scoped package:
-  assert.equal((await request('/element/@lion/button')).status, 404);
+  assert.equal((await request('/catalog/element/@lion/button')).status, 404);
 
   // Missing element name on non-scoped package:
-  assert.equal((await request('/element/chessboard-element')).status, 404);
+  assert.equal((await request('/catalog/element/chessboard-element')).status, 404);
 
   // Extra path segments on scoped package:
-  assert.equal((await request('/element/@lion/button/a/b')).status, 404);
+  assert.equal((await request('/catalog/element/@lion/button/a/b')).status, 404);
 
   // Extra path segments on non-scoped package:
-  assert.equal((await request('/element/chessboard-element/a/b')).status, 404);
+  assert.equal((await request('/catalog/element/chessboard-element/a/b')).status, 404);
 });
 
 test.run();

--- a/packages/site-server/src/test/catalog/routes_test.ts
+++ b/packages/site-server/src/test/catalog/routes_test.ts
@@ -20,13 +20,22 @@ test('Returns 404 for malformed element page URL', async () => {
   assert.equal((await request('/catalog/element/@lion/button')).status, 404);
 
   // Missing element name on non-scoped package:
-  assert.equal((await request('/catalog/element/chessboard-element')).status, 404);
+  assert.equal(
+    (await request('/catalog/element/chessboard-element')).status,
+    404
+  );
 
   // Extra path segments on scoped package:
-  assert.equal((await request('/catalog/element/@lion/button/a/b')).status, 404);
+  assert.equal(
+    (await request('/catalog/element/@lion/button/a/b')).status,
+    404
+  );
 
   // Extra path segments on non-scoped package:
-  assert.equal((await request('/catalog/element/chessboard-element/a/b')).status, 404);
+  assert.equal(
+    (await request('/catalog/element/chessboard-element/a/b')).status,
+    404
+  );
 });
 
 test.run();

--- a/packages/site-server/src/test/catalog/search_test.ts
+++ b/packages/site-server/src/test/catalog/search_test.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {suite} from 'uvu';
+// eslint-disable-next-line import/extensions
+import * as assert from 'uvu/assert';
+
+const test = suite('Route tests');
+
+const request = async (path: string) => fetch(`http://127.0.0.1:5450${path}`);
+
+test('Finds a button', async () => {
+  // Import lion-button
+  assert.equal(
+    (await request('/catalog/element/@lion/button/lion-button')).status,
+    200
+  );
+
+  // Import sl-button
+  assert.equal(
+    (await request('/catalog/element/@shoelace-style/shoelace/sl-button'))
+      .status,
+    200
+  );
+
+  const response = await request('/catalog/search?query=button');
+  assert.equal(response.status, 200);
+  const result = await response.json();
+
+  // Shoelace has a few buttons that all get imported
+  assert.ok(result.elements.length > 2);
+});
+
+test.run();

--- a/packages/site-server/test/catalog/routes_test.js
+++ b/packages/site-server/test/catalog/routes_test.js
@@ -8,10 +8,10 @@ import * as assert from "uvu/assert";
 const test = suite("Route tests");
 const request = async (path) => fetch(`http://127.0.0.1:5450${path}`);
 test("Returns 404 for malformed element page URL", async () => {
-  assert.equal((await request("/element/")).status, 404);
-  assert.equal((await request("/element/@lion/button")).status, 404);
-  assert.equal((await request("/element/chessboard-element")).status, 404);
-  assert.equal((await request("/element/@lion/button/a/b")).status, 404);
-  assert.equal((await request("/element/chessboard-element/a/b")).status, 404);
+  assert.equal((await request("/catalog/element/")).status, 404);
+  assert.equal((await request("/catalog/element/@lion/button")).status, 404);
+  assert.equal((await request("/catalog/element/chessboard-element")).status, 404);
+  assert.equal((await request("/catalog/element/@lion/button/a/b")).status, 404);
+  assert.equal((await request("/catalog/element/chessboard-element/a/b")).status, 404);
 });
 test.run();


### PR DESCRIPTION
This moves the search endpoint to the site server, removes the graphql client from the site client, and adds an integration test.

Fixes https://github.com/webcomponents/webcomponents.org/issues/1416