### PR TITLE
Use MWC for search input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3780,6 +3780,20 @@
         "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
+    "node_modules/@material/web": {
+      "version": "1.0.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@material/web/-/web-1.0.0-pre.1.tgz",
+      "integrity": "sha512-wDeQvRPBO/JY5l8K8Fgvkdfnj42uhCJbxn7a3IlQadqoBFoignMogfDrwfTxtV6HHOELktYlHkXgCN8RxgtrIQ==",
+      "dependencies": {
+        "lit": "^2.3.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@material/web/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -23814,6 +23828,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@lit-labs/task": "^2.0.0",
+        "@material/web": "^1.0.0-pre.1",
         "@webcomponents/catalog-api": "^0.0.0",
         "lit": "^2.6.0",
         "lit-analyzer": "^1.2.1"
@@ -26804,6 +26819,22 @@
         "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
+    "@material/web": {
+      "version": "1.0.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@material/web/-/web-1.0.0-pre.1.tgz",
+      "integrity": "sha512-wDeQvRPBO/JY5l8K8Fgvkdfnj42uhCJbxn7a3IlQadqoBFoignMogfDrwfTxtV6HHOELktYlHkXgCN8RxgtrIQ==",
+      "requires": {
+        "lit": "^2.3.0",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -27671,6 +27702,7 @@
       "version": "file:packages/site-client",
       "requires": {
         "@lit-labs/task": "^2.0.0",
+        "@material/web": "*",
         "@webcomponents/catalog-api": "^0.0.0",
         "lit": "^2.6.0",
         "lit-analyzer": "^1.2.1"
@@ -27696,7 +27728,7 @@
         "@types/koa": "^2.13.5",
         "@types/koa__cors": "^3.3.0",
         "@types/koa__router": "^12.0.0",
-        "@types/koa-bodyparser": "*",
+        "@types/koa-bodyparser": "^4.3.10",
         "@types/koa-conditional-get": "^2.0.0",
         "@types/koa-etag": "^3.0.0",
         "@types/koa-static": "^4.0.2",

--- a/packages/site-client/package.json
+++ b/packages/site-client/package.json
@@ -87,6 +87,7 @@
   },
   "dependencies": {
     "@lit-labs/task": "^2.0.0",
+    "@material/web": "^1.0.0-pre.1",
     "@webcomponents/catalog-api": "^0.0.0",
     "lit": "^2.6.0",
     "lit-analyzer": "^1.2.1"

--- a/packages/site-client/src/pages/catalog/wco-catalog-search.ts
+++ b/packages/site-client/src/pages/catalog/wco-catalog-search.ts
@@ -6,6 +6,12 @@
 
 import {html, css, LitElement} from 'lit';
 import {customElement, query, state} from 'lit/decorators.js';
+
+import '@material/web/textfield/outlined-text-field.js';
+import type {MdOutlinedTextField} from '@material/web/textfield/outlined-text-field.js';
+
+import '@material/web/icon/icon.js';
+
 import type {CustomElement} from '@webcomponents/catalog-api/lib/schema.js';
 
 import './wco-element-card.js';
@@ -27,17 +33,30 @@ export class WCOCatalogSearch extends LitElement {
       grid-auto-rows: 200px;
       gap: 8px;
     }
+
+    md-outlined-text-field {
+      width: 40em;
+      --md-outlined-field-container-shape-start-start: 28px;
+      --md-outlined-field-container-shape-start-end: 28px;
+      --md-outlined-field-container-shape-end-start: 28px;
+      --md-outlined-field-container-shape-end-end: 28px;
+    }
   `;
 
-  @query('input')
-  private _search!: HTMLInputElement;
+  @query('#search')
+  private _search!: MdOutlinedTextField;
 
   @state()
   private _elements: Array<CustomElement> | undefined;
 
   render() {
     return html`
-      <p>Search: <input id="search" @change=${this._onChange} /></p>
+      <section id="search-panel">
+        <h2>Web Components.org Catalog</h2>
+        <md-outlined-text-field id="search" @change=${this._onChange}
+          ><md-icon slot="leadingicon">search</md-icon></md-outlined-text-field
+        >
+      </section>
       <div>
         ${this._elements?.map(
           (e) => html`<wco-element-card .element=${e}></wco-element-card>`

--- a/packages/site-server/src/lib/catalog/routes/catalog-page.ts
+++ b/packages/site-server/src/lib/catalog/routes/catalog-page.ts
@@ -11,7 +11,31 @@ import {html} from 'lit';
 import {Readable} from 'stream';
 import Router from '@koa/router';
 
+import {LitElementRenderer} from '@lit-labs/ssr/lib/lit-element-renderer.js';
+import {
+  ElementRenderer,
+  ElementRendererConstructor,
+} from '@lit-labs/ssr/lib/element-renderer.js';
+
 import '@webcomponents/internal-site-client/lib/pages/catalog/wco-catalog-page.js';
+
+const excludeElements = (
+  renderer: ElementRendererConstructor,
+  tagNames: Array<string>
+) => {
+  return class ExcludeElementRenderer extends ElementRenderer {
+    static matchesClass(
+      ceClass: typeof HTMLElement,
+      tagName: string,
+      attributes: Map<string, string>
+    ) {
+      if (tagNames.includes(tagName)) {
+        return false;
+      }
+      return renderer.matchesClass(ceClass, tagName, attributes);
+    }
+  };
+};
 
 export const handleCatalogRoute = async (
   context: ParameterizedContext<
@@ -25,11 +49,18 @@ export const handleCatalogRoute = async (
   globalThis.location = new URL(context.URL.href) as unknown as Location;
 
   context.body = Readable.from(
-    renderPage({
-      title: `Web Components Catalog`,
-      initScript: '/js/catalog/boot.js',
-      content: html`<wco-catalog-page></wco-catalog-page>`,
-    })
+    renderPage(
+      {
+        title: `Web Components Catalog`,
+        initScript: '/js/catalog/boot.js',
+        content: html`<wco-catalog-page></wco-catalog-page>`,
+      },
+      {
+        elementRenderers: [
+          excludeElements(LitElementRenderer, ['md-outlined-text-field']),
+        ],
+      }
+    )
   );
   context.type = 'html';
   context.status = 200;

--- a/packages/site-templates/src/base.ts
+++ b/packages/site-templates/src/base.ts
@@ -14,6 +14,15 @@ import {escapeHTML} from './escape-html.js';
 export {unsafeHTML} from 'lit/directives/unsafe-html.js';
 export {html} from 'lit';
 
+// These are needed to load MWC components
+// See https://github.com/material-components/material-web/issues/3733
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).FormData = class FormData {};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).FormDataEvent = class FormDataEvent extends Event {};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).HTMLInputElement = class HTMLInputElement {};
+
 export function* renderPage(
   data: {
     scripts?: Array<string>;


### PR DESCRIPTION
This does the minimum I can see to get MWC components working in Lit SSR:
* Exclude them from server rendering with a custom renderer that wraps and conditionally disables LitElementRenderer
* Path `globalThis` with dummy classes that MWC uses in decorator metadata