### PR TITLE
Add workflow that automatically adds new webcomponents.org issues to the lit project board

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -1,0 +1,47 @@
+# GitHub action that automatically adds newly filed issues to the Lit project.
+#
+# Based on the example at
+# https://docs.github.com/en/issues/trying-out-the-new-projects-experience/automating-projects#example-workflow-authenticating-with-a-personal-access-token
+on:
+  issues:
+    types: [opened]
+jobs:
+  add-issue-to-project:
+    # Don't run on forks. Issues on forks aren't relevant, and secrets aren't
+    # available anyway.
+    if: github.repository == 'lit/lit'
+
+    runs-on: ubuntu-latest
+    steps:
+      # Finds the global entity ID for the project and adds it to an environment variable
+      # for the next step to consume.
+      - name: Get project ID
+        env:
+          GITHUB_TOKEN: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
+          ORGANIZATION: lit
+          PROJECT_NUMBER: 4
+        run: |
+          gh api graphql -f query='
+            query($organization: String!, $project_number: Int!) {
+              organization(login: $organization){
+                projectV2(number: $project_number) {
+                  id
+                }
+              }
+            }' -f organization=$ORGANIZATION -F project_number=$PROJECT_NUMBER > project_data.json
+
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+
+      - name: Add issue to project
+        env:
+          GITHUB_TOKEN: ${{ secrets.LIT_ROBOT_AUTOMATION_PAT }}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          gh api graphql -f query='
+            mutation($project_id:ID!, $issue_id:ID!) {
+              addProjectV2ItemById(input: {projectId: $project_id, contentId: $issue_id}) {
+                item {
+                  id
+                }
+              }
+            }' -f project_id=$PROJECT_ID -f issue_id=$ISSUE_ID

--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -9,7 +9,7 @@ jobs:
   add-issue-to-project:
     # Don't run on forks. Issues on forks aren't relevant, and secrets aren't
     # available anyway.
-    if: github.repository == 'lit/lit'
+    if: github.repository == 'webcomponents/webcomponents.org'
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I'm not 100% sure if this will work yet. It is the same as the one we use at https://github.com/lit/lit/blob/main/.github/workflows/add-issues-to-project.yml. The last time I tried this, the API call here failed because the issue was not in the same org as the project. However, according to https://github.com/orgs/community/discussions/6212#discussioncomment-1781562 this may now work.  I had to create a new lit-robot automation PAT because the old one was not saved anywhere. The new one is saved in the appropriate internal place. Let's see what happens!

If this works, as a followup I will have it automatically add the webcomponents.org category